### PR TITLE
Add more PHP versions to Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,15 @@
 language: php
 php:
   - 5.5
+  - 5.6
+  - hhvm
+  - hhvm-nightly
+
+matrix:
+  allow_failures:
+    - php: hhvm
+    - php: hhvm-nightly
+
 before_script:
   - composer selfupdate
   - composer install --prefer-dist -o


### PR DESCRIPTION
- Run in 5.6 version
- Run in hhvm
- Run in hhvm-nightly

It allows HHVM to fail because PHPUnit [does](https://github.com/sebastianbergmann/phpunit/blob/master/.travis.yml#L12-L15) and since you're using PHPUnit to validate the build, there is no reason for do in a different way, IMO.
