### PR TITLE
Fixed hmac::verify

### DIFF
--- a/src/Signer/Hmac.php
+++ b/src/Signer/Hmac.php
@@ -28,6 +28,10 @@ abstract class Hmac extends BaseSigner
      */
     public function verify($expected, $payload, $key)
     {
+        if (!is_string($expected)) {
+            return false;
+        }
+
         $callback = function_exists('hash_equals') ? 'hash_equals' : [$this, 'hashEquals'];
 
         return call_user_func($callback, $expected, $this->createHash($payload, $key));

--- a/test/Signer/HmacTest.php
+++ b/test/Signer/HmacTest.php
@@ -79,6 +79,16 @@ class HmacTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      *
+     * @covers Lcobucci\JWT\Signer\Hmac::verify
+     */
+    public function verifyShouldReturnFalseWhenExpectedHashIsNotString()
+    {
+        $this->assertFalse($this->signer->verify(false, 'test', '1234'));
+    }
+
+    /**
+     * @test
+     *
      * @covers Lcobucci\JWT\Signer\Hmac::hashEquals
      */
     public function hashEqualsShouldReturnFalseWhenExpectedHashHasDifferentLengthThanGenerated()


### PR DESCRIPTION
$expected could be not a string (namely false), when function base64_decode finds in the string invalid chars. In this case, function hash_equals triggers warning "hash_equals(): Expected known_string to be a string, boolean given".

This fix solves the problem.