### PR TITLE
Replaced Token->validate with Validator class handling token validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,23 +98,23 @@ $data->setId('4f1g23a12aa');
 
 $results = (new Validator($data))->validate($token);
 
-echo ($results->valid() ? 'Data is valid' : 'Data is not valid!') . PHP_EOL . PHP_EOL;
+echo ($results->isValid() ? 'Data is valid' : 'Data is not valid!') . PHP_EOL . PHP_EOL;
 
 $data->setCurrentTime(time() + 4000); // changing the validation time to future
 $data->setAudience('http://wrong.example.org');
 $results = (new Validator($data))->validate($token);
 
-if ($results->valid()) {
+if ($results->isValid()) {
     echo 'Data is valid' . PHP_EOL;
 } else {
 
+    $errors = $results->getErrors();
     // false, because token is expired since current time is greater than exp
-    if (($results instanceof Results) && $results->isExpired()) {
+    if (isset($errors['exp'])) {
         echo 'Data is expired' . PHP_EOL;
     }
-
-    // returns an array with [<name> => <message>] revealing the data is invalid on aud and exp
-    var_dump($results->errors());
+    
+    var_dump($errors);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -75,25 +75,28 @@ echo $token->getClaim('uid'); // will print "1"
 We can easily validate if the token is valid (using the previous token as example):
 
 ```php
+use Lcobucci\JWT\Validator;
 use Lcobucci\JWT\ValidationData;
 
+$validator = new Validator();
 $data = new ValidationData(); // It will use the current time to validate (iat, nbf and exp)
 $data->setIssuer('http://example.com');
 $data->setAudience('http://example.org');
 $data->setId('4f1g23a12aa');
 
-var_dump($token->validate($data)); // true, because validation information is equals to data contained on the token
+var_dump($validator->validate($token, $data)); // true, because validation information is equals to data contained on the token
 
 $data->setCurrentTime(time() + 4000); // changing the validation time to future
 
-var_dump($token->validate($data)); // false, because token is expired since current time is greater than exp
+var_dump($validator->validate($token, $data)); // false, because token is expired since current time is greater than exp
+var_dump($validator->getErrors()); // returns an array with ['exp' => false] revealing the data is invalid on exp
 ```
 
 #### Important
 
 - You have to configure ```ValidationData``` informing all claims you want to validate the token.
 - If ```ValidationData``` contains claims that are not being used in token or token has claims that are not
-configured in ```ValidationData``` they will be ignored by ```Token::validate()```.
+configured in ```ValidationData``` they will be ignored by ```Validator::validate()```.
 - ```exp```, ```nbf``` and ```iat``` claims are configured by default in ```ValidationData::__construct()```
 with the current UNIX time (```time()```).
 

--- a/src/Claim/EqualsTo.php
+++ b/src/Claim/EqualsTo.php
@@ -28,14 +28,7 @@ class EqualsTo extends Basic implements Claim, Validatable
     {
         $name = $this->getName();
         if ($data->has($name) && ($this->getValue() != $data->get($name))) {
-            throw new InvalidClaimException(
-                sprintf(
-                    "The value of '%s' (%s) does not equal the validation value (%s)",
-                    $name,
-                    $data->get($name),
-                    $this->getValue()
-                )
-            );
+            throw new InvalidClaimException($name, "The claim value does not equal the validation value");
         }
     }
 }

--- a/src/Claim/EqualsTo.php
+++ b/src/Claim/EqualsTo.php
@@ -30,7 +30,7 @@ class EqualsTo extends Basic implements Claim, Validatable
         if ($data->has($name) && ($this->getValue() != $data->get($name))) {
             throw new InvalidClaimException(
                 sprintf(
-                    "The value of '%s' (%s) does not equal the claim value (%s)",
+                    "The value of '%s' (%s) does not equal the validation value (%s)",
                     $name,
                     $data->get($name),
                     $this->getValue()

--- a/src/Claim/EqualsTo.php
+++ b/src/Claim/EqualsTo.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Lcobucci\JWT\Claim;
 
 use Lcobucci\JWT\Claim;
+use Lcobucci\JWT\Exception\InvalidClaimException;
 use Lcobucci\JWT\ValidationData;
 
 /**
@@ -23,12 +24,18 @@ class EqualsTo extends Basic implements Claim, Validatable
     /**
      * {@inheritdoc}
      */
-    public function validate(ValidationData $data): bool
+    public function validate(ValidationData $data)
     {
-        if ($data->has($this->getName())) {
-            return $this->getValue() === $data->get($this->getName());
+        $name = $this->getName();
+        if ($data->has($name) && ($this->getValue() != $data->get($name))) {
+            throw new InvalidClaimException(
+                sprintf(
+                    "The value of '%s' (%s) does not equal the claim value (%s)",
+                    $name,
+                    $data->get($name),
+                    $this->getValue()
+                )
+            );
         }
-
-        return true;
     }
 }

--- a/src/Claim/GreaterOrEqualsTo.php
+++ b/src/Claim/GreaterOrEqualsTo.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Lcobucci\JWT\Claim;
 
 use Lcobucci\JWT\Claim;
-use Lcobucci\JWT\Exception\InvalidClaimException;
+use Lcobucci\JWT\Exception\RangeException;
 use Lcobucci\JWT\ValidationData;
 
 /**
@@ -28,14 +28,7 @@ class GreaterOrEqualsTo extends Basic implements Claim, Validatable
     {
         $name = $this->getName();
         if ($data->has($name) && ($this->getValue() < $data->get($name))) {
-            throw new InvalidClaimException(
-                sprintf(
-                    "The value of '%s' (%d) is not greater than or equals the validation value (%d)",
-                    $name,
-                    $data->get($name),
-                    $this->getValue()
-                )
-            );
+            throw new RangeException($name, "The claim value should be greater than the validation value");
         }
     }
 }

--- a/src/Claim/GreaterOrEqualsTo.php
+++ b/src/Claim/GreaterOrEqualsTo.php
@@ -30,7 +30,7 @@ class GreaterOrEqualsTo extends Basic implements Claim, Validatable
         if ($data->has($name) && ($this->getValue() < $data->get($name))) {
             throw new InvalidClaimException(
                 sprintf(
-                    "The value of '%s' (%d) is not greater than or equals the claim value (%d)",
+                    "The value of '%s' (%d) is not greater than or equals the validation value (%d)",
                     $name,
                     $data->get($name),
                     $this->getValue()

--- a/src/Claim/GreaterOrEqualsTo.php
+++ b/src/Claim/GreaterOrEqualsTo.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Lcobucci\JWT\Claim;
 
 use Lcobucci\JWT\Claim;
+use Lcobucci\JWT\Exception\InvalidClaimException;
 use Lcobucci\JWT\ValidationData;
 
 /**
@@ -23,11 +24,20 @@ class GreaterOrEqualsTo extends Basic implements Claim, Validatable
     /**
      * {@inheritdoc}
      */
-    public function validate(ValidationData $data): bool
+    public function validate(ValidationData $data)
     {
-        if ($data->has($this->getName())) {
-            return $this->getValue() >= $data->get($this->getName());
+        $name = $this->getName();
+        if ($data->has($name) && ($this->getValue() < $data->get($name))) {
+            throw new InvalidClaimException(
+                sprintf(
+                    "The value of '%s' (%d) is not greater than or equals the claim value (%d)",
+                    $name,
+                    $data->get($name),
+                    $this->getValue()
+                )
+            );
         }
+
 
         return true;
     }

--- a/src/Claim/GreaterOrEqualsTo.php
+++ b/src/Claim/GreaterOrEqualsTo.php
@@ -37,8 +37,5 @@ class GreaterOrEqualsTo extends Basic implements Claim, Validatable
                 )
             );
         }
-
-
-        return true;
     }
 }

--- a/src/Claim/LesserOrEqualsTo.php
+++ b/src/Claim/LesserOrEqualsTo.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Lcobucci\JWT\Claim;
 
 use Lcobucci\JWT\Claim;
-use Lcobucci\JWT\Exception\InvalidClaimException;
+use Lcobucci\JWT\Exception\RangeException;
 use Lcobucci\JWT\ValidationData;
 
 /**
@@ -28,14 +28,7 @@ class LesserOrEqualsTo extends Basic implements Claim, Validatable
     {
         $name = $this->getName();
         if ($data->has($name) && ($this->getValue() > $data->get($name))) {
-            throw new InvalidClaimException(
-                sprintf(
-                    "The value of '%s' (%d) is not lesser than or equals the validation value (%d)",
-                    $name,
-                    $data->get($name),
-                    $this->getValue()
-                )
-            );
+            throw new RangeException($name, "The claim value should be less than the validation value");
         }
     }
 }

--- a/src/Claim/LesserOrEqualsTo.php
+++ b/src/Claim/LesserOrEqualsTo.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Lcobucci\JWT\Claim;
 
 use Lcobucci\JWT\Claim;
+use Lcobucci\JWT\Exception\InvalidClaimException;
 use Lcobucci\JWT\ValidationData;
 
 /**
@@ -23,12 +24,18 @@ class LesserOrEqualsTo extends Basic implements Claim, Validatable
     /**
      * {@inheritdoc}
      */
-    public function validate(ValidationData $data): bool
+    public function validate(ValidationData $data)
     {
-        if ($data->has($this->getName())) {
-            return $this->getValue() <= $data->get($this->getName());
+        $name = $this->getName();
+        if ($data->has($name) && ($this->getValue() > $data->get($name))) {
+            throw new InvalidClaimException(
+                sprintf(
+                    "The value of '%s' (%d) is not lesser than or equals the claim value (%d)",
+                    $name,
+                    $data->get($name),
+                    $this->getValue()
+                )
+            );
         }
-
-        return true;
     }
 }

--- a/src/Claim/LesserOrEqualsTo.php
+++ b/src/Claim/LesserOrEqualsTo.php
@@ -30,7 +30,7 @@ class LesserOrEqualsTo extends Basic implements Claim, Validatable
         if ($data->has($name) && ($this->getValue() > $data->get($name))) {
             throw new InvalidClaimException(
                 sprintf(
-                    "The value of '%s' (%d) is not lesser than or equals the claim value (%d)",
+                    "The value of '%s' (%d) is not lesser than or equals the validation value (%d)",
                     $name,
                     $data->get($name),
                     $this->getValue()

--- a/src/Claim/Validatable.php
+++ b/src/Claim/Validatable.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Lcobucci\JWT\Claim;
 
+use Lcobucci\JWT\Exception\InvalidClaimException;
 use Lcobucci\JWT\ValidationData;
 
 /**
@@ -20,11 +21,11 @@ use Lcobucci\JWT\ValidationData;
 interface Validatable
 {
     /**
-     * Returns if claim is valid according with given data
+     * Throws an InvalidClaimException if the given data is invalid to  claim
      *
      * @param ValidationData $data
      *
-     * @return bool
+     * @throws InvalidClaimException
      */
-    public function validate(ValidationData $data): bool;
+    public function validate(ValidationData $data);
 }

--- a/src/Exception/InvalidClaimException.php
+++ b/src/Exception/InvalidClaimException.php
@@ -9,10 +9,26 @@ declare(strict_types=1);
 
 namespace Lcobucci\JWT\Exception;
 
+use Exception;
+
 /**
  * Invalid claim exception to be thrown on claim validation
  */
 class InvalidClaimException extends \InvalidArgumentException
 {
+    private $claim;
 
+    public function __construct(string $claim, $message = "", $code = 0, Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+        $this->claim = $claim;
+    }
+
+    /**
+     * @return string
+     */
+    public function getClaim()
+    {
+        return $this->claim;
+    }
 }

--- a/src/Exception/InvalidClaimException.php
+++ b/src/Exception/InvalidClaimException.php
@@ -1,0 +1,7 @@
+<?php
+namespace Lcobucci\JWT\Exception;
+
+class InvalidClaimException extends \InvalidArgumentException
+{
+
+}

--- a/src/Exception/InvalidClaimException.php
+++ b/src/Exception/InvalidClaimException.php
@@ -1,6 +1,17 @@
 <?php
+/**
+ * This file is part of Lcobucci\JWT, a simple library to handle JWT and JWS
+ *
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ */
+
+declare(strict_types=1);
+
 namespace Lcobucci\JWT\Exception;
 
+/**
+ * Invalid claim exception to be thrown on claim validation
+ */
 class InvalidClaimException extends \InvalidArgumentException
 {
 

--- a/src/Exception/RangeException.php
+++ b/src/Exception/RangeException.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Created on 14/02/16 09:19
+ */
+
+namespace Lcobucci\JWT\Exception;
+
+class RangeException extends InvalidClaimException
+{
+
+}

--- a/src/Token.php
+++ b/src/Token.php
@@ -196,38 +196,6 @@ class Token
     }
 
     /**
-     * Validates if the token is valid
-     *
-     * @param ValidationData $data
-     *
-     * @return bool
-     */
-    public function validate(ValidationData $data): bool
-    {
-        foreach ($this->getValidatableClaims() as $claim) {
-            if (!$claim->validate($data)) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * Yields the validatable claims
-     *
-     * @return Generator
-     */
-    private function getValidatableClaims(): Generator
-    {
-        foreach ($this->claims as $claim) {
-            if ($claim instanceof Validatable) {
-                yield $claim;
-            }
-        }
-    }
-
-    /**
      * Returns the token payload
      *
      * @return string

--- a/src/Token.php
+++ b/src/Token.php
@@ -1,5 +1,5 @@
 <?php
-/**
+/*
  * This file is part of Lcobucci\JWT, a simple library to handle JWT and JWS
  *
  * @license http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
@@ -9,8 +9,6 @@ declare(strict_types=1);
 
 namespace Lcobucci\JWT;
 
-use Generator;
-use Lcobucci\JWT\Claim\Validatable;
 use Lcobucci\JWT\Signer\Key;
 use OutOfBoundsException;
 

--- a/src/Validation/ResultInterface.php
+++ b/src/Validation/ResultInterface.php
@@ -12,19 +12,19 @@ namespace Lcobucci\JWT\Validation;
 /**
  * Basic interface describing validation results
  */
-interface ResultsInterface
+interface ResultInterface
 {
     /**
      * Returns true on valid results
      *
      * @return bool
      */
-    public function valid(): bool;
+    public function isValid(): bool;
 
     /**
      * Returns an array with name => message
      *
      * @return array
      */
-    public function errors(): array;
+    public function getErrors(): array;
 }

--- a/src/Validation/Results.php
+++ b/src/Validation/Results.php
@@ -43,12 +43,4 @@ class Results implements ResultInterface
     {
         return $this->errors;
     }
-
-    /**
-     * @return bool
-     */
-    public function isExpired(): bool
-    {
-        return isset($this->errors['exp']);
-    }
 }

--- a/src/Validation/Results.php
+++ b/src/Validation/Results.php
@@ -8,6 +8,7 @@
 declare(strict_types=1);
 
 namespace Lcobucci\JWT\Validation;
+use Lcobucci\JWT\Exception\InvalidClaimException;
 
 /**
  * Results returned by validation
@@ -20,12 +21,11 @@ class Results implements ResultInterface
     private $errors = [];
 
     /**
-     * @param string $name
-     * @param string $message
+     * @param InvalidClaimException $exception
      */
-    public function addError(string $name, string $message)
+    public function addError(InvalidClaimException $exception)
     {
-        $this->errors[$name] = $message;
+        $this->errors[$exception->getClaim()] = $exception->getMessage();
     }
 
     /**

--- a/src/Validation/Results.php
+++ b/src/Validation/Results.php
@@ -12,7 +12,7 @@ namespace Lcobucci\JWT\Validation;
 /**
  * Results returned by validation
  */
-class Results implements ResultsInterface
+class Results implements ResultInterface
 {
     /**
      * @var array
@@ -31,7 +31,7 @@ class Results implements ResultsInterface
     /**
      * @inheritdoc
      */
-    public function valid(): bool
+    public function isValid(): bool
     {
         return empty($this->errors);
     }
@@ -39,7 +39,7 @@ class Results implements ResultsInterface
     /**
      * @inheritdoc
      */
-    public function errors(): array
+    public function getErrors(): array
     {
         return $this->errors;
     }

--- a/src/Validation/Results.php
+++ b/src/Validation/Results.php
@@ -1,0 +1,36 @@
+<?php
+namespace Lcobucci\JWT\Validation;
+
+class Results implements ResultsInterface
+{
+    private $errors = [];
+
+    /**
+     * @param string $name
+     * @param string $message
+     */
+    public function addError(string $name, string $message)
+    {
+        $this->errors[$name] = $message;
+    }
+
+    /** @inheritdoc */
+    public function valid(): bool
+    {
+        return empty($this->errors);
+    }
+
+    /** @inheritdoc */
+    public function errors(): array
+    {
+        return $this->errors;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isExpired(): bool
+    {
+        return isset($this->errors['exp']);
+    }
+}

--- a/src/Validation/Results.php
+++ b/src/Validation/Results.php
@@ -1,8 +1,22 @@
 <?php
+/**
+ * This file is part of Lcobucci\JWT, a simple library to handle JWT and JWS
+ *
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ */
+
+declare(strict_types=1);
+
 namespace Lcobucci\JWT\Validation;
 
+/**
+ * Results returned by validation
+ */
 class Results implements ResultsInterface
 {
+    /**
+     * @var array
+     */
     private $errors = [];
 
     /**
@@ -14,13 +28,17 @@ class Results implements ResultsInterface
         $this->errors[$name] = $message;
     }
 
-    /** @inheritdoc */
+    /**
+     * @inheritdoc
+     */
     public function valid(): bool
     {
         return empty($this->errors);
     }
 
-    /** @inheritdoc */
+    /**
+     * @inheritdoc
+     */
     public function errors(): array
     {
         return $this->errors;

--- a/src/Validation/ResultsInterface.php
+++ b/src/Validation/ResultsInterface.php
@@ -1,9 +1,30 @@
 <?php
+/**
+ * This file is part of Lcobucci\JWT, a simple library to handle JWT and JWS
+ *
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ */
+
+declare(strict_types=1);
+
 namespace Lcobucci\JWT\Validation;
 
+/**
+ * Basic interface describing validation results
+ */
 interface ResultsInterface
 {
+    /**
+     * Returns true on valid results
+     *
+     * @return bool
+     */
     public function valid(): bool;
 
+    /**
+     * Returns an array with name => message
+     *
+     * @return array
+     */
     public function errors(): array;
 }

--- a/src/Validation/ResultsInterface.php
+++ b/src/Validation/ResultsInterface.php
@@ -1,0 +1,9 @@
+<?php
+namespace Lcobucci\JWT\Validation;
+
+interface ResultsInterface
+{
+    public function valid(): bool;
+
+    public function errors(): array;
+}

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * This file is part of Lcobucci\JWT, a simple library to handle JWT and JWS
+ *
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ */
+
+namespace Lcobucci\JWT;
+
+use Generator;
+use Lcobucci\JWT\Claim\Validatable;
+
+/**
+ * Class that validates token with defined validationData
+ *
+ * @author Danny Dörfel <danny.dorfel@gmail.com>
+ */
+class Validator
+{
+    protected $errors = [];
+
+    /**
+     * @param Token $token
+     * @param ValidationData $data
+     * @return bool
+     */
+    public function validate(Token $token, ValidationData $data): bool
+    {
+        $this->errors = [];
+        foreach ($this->getValidatableClaims($token) as $claim) {
+
+            if (! $data->has($claim->getName())) {
+                continue;
+            }
+
+            if (!$claim->validate($data)) {
+                $this->errors[$claim->getName()] = false;
+            }
+        }
+
+        return count($this->errors) ? false : true;
+    }
+
+    /**
+     * @return array
+     */
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+
+    /**
+     * Yields the validatable claims
+     *
+     * @param Token $token
+     * @return Generator
+     */
+    private function getValidatableClaims(Token $token)
+    {
+        foreach ($token->getClaims() as $claim) {
+            if ($claim instanceof Validatable) {
+                yield $claim;
+            }
+        }
+    }
+}

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -5,6 +5,8 @@
  * @license http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
  */
 
+declare(strict_types=1);
+
 namespace Lcobucci\JWT;
 
 use Generator;
@@ -14,7 +16,7 @@ use Lcobucci\JWT\Validation\Results;
 use Lcobucci\JWT\Validation\ResultsInterface;
 
 /**
- * Class that validates token with defined validationData
+ * This Class validates a token with defined validationData
  *
  * @author Danny Dörfel <danny.dorfel@gmail.com>
  */

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -27,18 +27,15 @@ class Validator
     public function validate(Token $token, ValidationData $data): bool
     {
         $this->errors = [];
+
         foreach ($this->getValidatableClaims($token) as $claim) {
 
-            if (! $data->has($claim->getName())) {
-                continue;
-            }
-
-            if (!$claim->validate($data)) {
+            if ($data->has($claim->getName()) && !$claim->validate($data)) {
                 $this->errors[$claim->getName()] = false;
             }
         }
 
-        return count($this->errors) ? false : true;
+        return count($this->errors) === 0;
     }
 
     /**

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -13,7 +13,7 @@ use Generator;
 use Lcobucci\JWT\Claim\Validatable;
 use Lcobucci\JWT\Exception\InvalidClaimException;
 use Lcobucci\JWT\Validation\Results;
-use Lcobucci\JWT\Validation\ResultsInterface;
+use Lcobucci\JWT\Validation\ResultInterface;
 
 /**
  * This Class validates a token with defined validationData
@@ -34,9 +34,9 @@ class Validator implements ValidatorInterface
 
     /**
      * @param Token $token
-     * @return ResultsInterface
+     * @return ResultInterface
      */
-    public function validate(Token $token): ResultsInterface
+    public function validate(Token $token): ResultInterface
     {
         $results = new Results();
 

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -44,7 +44,7 @@ class Validator implements ValidatorInterface
             try {
                 $claim->validate($this->data);
             } catch (InvalidClaimException $exception) {
-                $results->addError($claim->getName(), $exception->getMessage());
+                $results->addError($exception);
             }
         }
 

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -17,7 +17,7 @@ use Lcobucci\JWT\Claim\Validatable;
  */
 class Validator
 {
-    protected $errors = [];
+    private $errors = [];
 
     /**
      * @param Token $token
@@ -47,12 +47,10 @@ class Validator
     }
 
     /**
-     * Yields the validatable claims
-     *
      * @param Token $token
      * @return Generator
      */
-    private function getValidatableClaims(Token $token)
+    private function getValidatableClaims(Token $token): Generator
     {
         foreach ($token->getClaims() as $claim) {
             if ($claim instanceof Validatable) {

--- a/src/ValidatorInterface.php
+++ b/src/ValidatorInterface.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * This file is part of Lcobucci\JWT, a simple library to handle JWT and JWS
+ *
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ */
+
+namespace Lcobucci\JWT;
+
+use Lcobucci\JWT\Validation\ResultsInterface;
+
+interface ValidatorInterface
+{
+    /**
+     * @param Token $token
+     * @return ResultsInterface
+     */
+    public function validate(Token $token): ResultsInterface;
+}

--- a/src/ValidatorInterface.php
+++ b/src/ValidatorInterface.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace Lcobucci\JWT;
 
-use Lcobucci\JWT\Validation\ResultsInterface;
+use Lcobucci\JWT\Validation\ResultInterface;
 
 /**
  * Basic interface describing the validator api
@@ -18,7 +18,7 @@ interface ValidatorInterface
 {
     /**
      * @param Token $token
-     * @return ResultsInterface
+     * @return ResultInterface
      */
-    public function validate(Token $token): ResultsInterface;
+    public function validate(Token $token): ResultInterface;
 }

--- a/src/ValidatorInterface.php
+++ b/src/ValidatorInterface.php
@@ -5,10 +5,15 @@
  * @license http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
  */
 
+declare(strict_types=1);
+
 namespace Lcobucci\JWT;
 
 use Lcobucci\JWT\Validation\ResultsInterface;
 
+/**
+ * Basic interface describing the validator api
+ */
 interface ValidatorInterface
 {
     /**

--- a/test/functional/UnsignedTokenTest.php
+++ b/test/functional/UnsignedTokenTest.php
@@ -13,6 +13,7 @@ use Lcobucci\JWT\Builder;
 use Lcobucci\JWT\Parser;
 use Lcobucci\JWT\Token;
 use Lcobucci\JWT\ValidationData;
+use Lcobucci\JWT\Validator;
 
 /**
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
@@ -85,11 +86,12 @@ class UnsignedTokenTest extends \PHPUnit_Framework_TestCase
      */
     public function tokenValidationShouldReturnWhenEverythingIsFine(Token $generated)
     {
+        $validator = new Validator();
         $data = new ValidationData(self::CURRENT_TIME - 10);
         $data->setAudience('http://client.abc.com');
         $data->setIssuer('http://api.abc.com');
 
-        $this->assertTrue($generated->validate($data));
+        $this->assertTrue($validator->validate($generated, $data));
     }
 
     /**
@@ -110,7 +112,8 @@ class UnsignedTokenTest extends \PHPUnit_Framework_TestCase
      */
     public function tokenValidationShouldReturnFalseWhenExpectedDataDontMatch(ValidationData $data, Token $generated)
     {
-        $this->assertFalse($generated->validate($data));
+        $validator = new Validator();
+        $this->assertFalse($validator->validate($generated, $data));
     }
 
     public function invalidValidationData()

--- a/test/functional/UnsignedTokenTest.php
+++ b/test/functional/UnsignedTokenTest.php
@@ -93,7 +93,7 @@ class UnsignedTokenTest extends \PHPUnit_Framework_TestCase
         $validator = new Validator($data);
         $results = $validator->validate($generated);
 
-        $this->assertTrue($results->valid());
+        $this->assertTrue($results->isValid());
     }
 
     /**
@@ -116,7 +116,7 @@ class UnsignedTokenTest extends \PHPUnit_Framework_TestCase
     {
         $validator = new Validator($data);
         $results = $validator->validate($generated);
-        $this->assertFalse($results->valid());
+        $this->assertFalse($results->isValid());
     }
 
     public function invalidValidationData()

--- a/test/functional/UnsignedTokenTest.php
+++ b/test/functional/UnsignedTokenTest.php
@@ -86,12 +86,14 @@ class UnsignedTokenTest extends \PHPUnit_Framework_TestCase
      */
     public function tokenValidationShouldReturnWhenEverythingIsFine(Token $generated)
     {
-        $validator = new Validator();
         $data = new ValidationData(self::CURRENT_TIME - 10);
         $data->setAudience('http://client.abc.com');
         $data->setIssuer('http://api.abc.com');
 
-        $this->assertTrue($validator->validate($generated, $data));
+        $validator = new Validator($data);
+        $results = $validator->validate($generated);
+
+        $this->assertTrue($results->valid());
     }
 
     /**
@@ -112,8 +114,9 @@ class UnsignedTokenTest extends \PHPUnit_Framework_TestCase
      */
     public function tokenValidationShouldReturnFalseWhenExpectedDataDontMatch(ValidationData $data, Token $generated)
     {
-        $validator = new Validator();
-        $this->assertFalse($validator->validate($generated, $data));
+        $validator = new Validator($data);
+        $results = $validator->validate($generated);
+        $this->assertFalse($results->valid());
     }
 
     public function invalidValidationData()

--- a/test/unit/Claim/EqualsToTest.php
+++ b/test/unit/Claim/EqualsToTest.php
@@ -27,15 +27,16 @@ class EqualsToTest extends \PHPUnit_Framework_TestCase
      *
      * @covers Lcobucci\JWT\Claim\EqualsTo::validate
      */
-    public function validateShouldReturnTrueWhenValidationDontHaveTheClaim()
+    public function validateShouldReturnWhenValidationDontHaveTheClaim()
     {
         $claim = new EqualsTo('iss', 'test');
 
-        $this->assertTrue($claim->validate(new ValidationData()));
+        $this->assertNull($claim->validate(new ValidationData()));
     }
 
     /**
      * @test
+     * @expectedException \Lcobucci\JWT\Exception\InvalidClaimException
      *
      * @uses Lcobucci\JWT\Claim\Basic::__construct
      * @uses Lcobucci\JWT\Claim\Basic::getName
@@ -47,36 +48,13 @@ class EqualsToTest extends \PHPUnit_Framework_TestCase
      *
      * @covers Lcobucci\JWT\Claim\EqualsTo::validate
      */
-    public function validateShouldReturnTrueWhenValueIsEqualsToValidationData()
-    {
-        $claim = new EqualsTo('iss', 'test');
-
-        $data = new ValidationData();
-        $data->setIssuer('test');
-
-        $this->assertTrue($claim->validate($data));
-    }
-
-    /**
-     * @test
-     *
-     * @uses Lcobucci\JWT\Claim\Basic::__construct
-     * @uses Lcobucci\JWT\Claim\Basic::getName
-     * @uses Lcobucci\JWT\Claim\Basic::getValue
-     * @uses Lcobucci\JWT\ValidationData::__construct
-     * @uses Lcobucci\JWT\ValidationData::setIssuer
-     * @uses Lcobucci\JWT\ValidationData::has
-     * @uses Lcobucci\JWT\ValidationData::get
-     *
-     * @covers Lcobucci\JWT\Claim\EqualsTo::validate
-     */
-    public function validateShouldReturnFalseWhenValueIsNotEqualsToValidationData()
+    public function validateShouldRaiseExceptionWhenValueIsNotEqualsToValidationData()
     {
         $claim = new EqualsTo('iss', 'test');
 
         $data = new ValidationData();
         $data->setIssuer('test1');
 
-        $this->assertFalse($claim->validate($data));
+        $claim->validate($data);
     }
 }

--- a/test/unit/Claim/GreaterOrEqualsToTest.php
+++ b/test/unit/Claim/GreaterOrEqualsToTest.php
@@ -27,12 +27,13 @@ class GreaterOrEqualsToTest extends \PHPUnit_Framework_TestCase
      *
      * @covers Lcobucci\JWT\Claim\GreaterOrEqualsTo::validate
      */
-    public function validateShouldReturnTrueWhenValidationDontHaveTheClaim()
+    public function validateShouldReturnWhenValidationDontHaveTheClaim()
     {
         $claim = new GreaterOrEqualsTo('iss', 10);
 
-        $this->assertTrue($claim->validate(new ValidationData()));
+        $this->assertNull($claim->validate(new ValidationData()));
     }
+
 
     /**
      * @test
@@ -47,12 +48,12 @@ class GreaterOrEqualsToTest extends \PHPUnit_Framework_TestCase
      *
      * @covers Lcobucci\JWT\Claim\GreaterOrEqualsTo::validate
      */
-    public function validateShouldReturnTrueWhenValueIsGreaterThanValidationData()
+    public function validateShouldReturnWhenValueIsGreaterThanValidationData()
     {
         $claim = new GreaterOrEqualsTo('iat', 11);
         $data = new ValidationData(10);
 
-        $this->assertTrue($claim->validate($data));
+        $this->assertNull($claim->validate($data));
     }
 
     /**
@@ -68,16 +69,17 @@ class GreaterOrEqualsToTest extends \PHPUnit_Framework_TestCase
      *
      * @covers Lcobucci\JWT\Claim\GreaterOrEqualsTo::validate
      */
-    public function validateShouldReturnTrueWhenValueIsEqualsToValidationData()
+    public function validateShouldReturnWhenValueIsEqualsToValidationData()
     {
         $claim = new GreaterOrEqualsTo('iat', 10);
         $data = new ValidationData(10);
 
-        $this->assertTrue($claim->validate($data));
+        $this->assertNull($claim->validate($data));
     }
 
     /**
      * @test
+     * @expectedException \Lcobucci\JWT\Exception\InvalidClaimException
      *
      * @uses Lcobucci\JWT\Claim\Basic::__construct
      * @uses Lcobucci\JWT\Claim\Basic::getName
@@ -89,7 +91,7 @@ class GreaterOrEqualsToTest extends \PHPUnit_Framework_TestCase
      *
      * @covers Lcobucci\JWT\Claim\GreaterOrEqualsTo::validate
      */
-    public function validateShouldReturnFalseWhenValueIsLesserThanValidationData()
+    public function validateShouldRaiseExceptionWhenValueIsLesserThanValidationData()
     {
         $claim = new GreaterOrEqualsTo('iat', 10);
         $data = new ValidationData(11);

--- a/test/unit/Claim/LesserOrEqualsToTest.php
+++ b/test/unit/Claim/LesserOrEqualsToTest.php
@@ -27,11 +27,11 @@ class LesserOrEqualsToTest extends \PHPUnit_Framework_TestCase
      *
      * @covers Lcobucci\JWT\Claim\LesserOrEqualsTo::validate
      */
-    public function validateShouldReturnTrueWhenValidationDontHaveTheClaim()
+    public function validateShouldReturnWhenValidationDontHaveTheClaim()
     {
         $claim = new LesserOrEqualsTo('iss', 10);
 
-        $this->assertTrue($claim->validate(new ValidationData()));
+        $this->assertNull($claim->validate(new ValidationData()));
     }
 
     /**
@@ -47,12 +47,12 @@ class LesserOrEqualsToTest extends \PHPUnit_Framework_TestCase
      *
      * @covers Lcobucci\JWT\Claim\LesserOrEqualsTo::validate
      */
-    public function validateShouldReturnTrueWhenValueIsLesserThanValidationData()
+    public function validateShouldReturnWhenValueIsLesserThanValidationData()
     {
         $claim = new LesserOrEqualsTo('iat', 10);
         $data = new ValidationData(11);
 
-        $this->assertTrue($claim->validate($data));
+        $this->assertNull($claim->validate($data));
     }
 
     /**
@@ -68,16 +68,17 @@ class LesserOrEqualsToTest extends \PHPUnit_Framework_TestCase
      *
      * @covers Lcobucci\JWT\Claim\LesserOrEqualsTo::validate
      */
-    public function validateShouldReturnTrueWhenValueIsEqualsToValidationData()
+    public function validateShouldReturnWhenValueIsEqualsToValidationData()
     {
         $claim = new LesserOrEqualsTo('iat', 10);
         $data = new ValidationData(10);
 
-        $this->assertTrue($claim->validate($data));
+        $this->assertNull($claim->validate($data));
     }
 
     /**
      * @test
+     * @expectedException \Lcobucci\JWT\Exception\InvalidClaimException
      *
      * @uses Lcobucci\JWT\Claim\Basic::__construct
      * @uses Lcobucci\JWT\Claim\Basic::getName
@@ -89,7 +90,7 @@ class LesserOrEqualsToTest extends \PHPUnit_Framework_TestCase
      *
      * @covers Lcobucci\JWT\Claim\LesserOrEqualsTo::validate
      */
-    public function validateShouldReturnFalseWhenValueIsGreaterThanValidationData()
+    public function validateShouldRaiseExceptionWhenValueIsGreaterThanValidationData()
     {
         $claim = new LesserOrEqualsTo('iat', 11);
         $data = new ValidationData(10);

--- a/test/unit/ResultsTest.php
+++ b/test/unit/ResultsTest.php
@@ -55,24 +55,4 @@ class ResultsTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('iss', $results->getErrors());
         $this->assertEquals('Value is not valid', $errors['iss']);
     }
-
-    /**
-     * @test
-     *
-     * @uses Lcobucci\JWT\Validator::__construct
-     *
-     * @covers Lcobucci\JWT\Validation\Results::addError
-     * @covers Lcobucci\JWT\Validation\Results::valid
-     */
-    public function isExpiredShouldReturnTrueIfExpErrorIsSet()
-    {
-        $results = new Results();
-        $results->addError('exp', 'Expired');
-
-        $errors = $results->getErrors();
-        $this->assertFalse($results->isValid());
-        $this->assertArrayHasKey('exp', $results->getErrors());
-        $this->assertEquals('Expired', $errors['exp']);
-        $this->assertTrue($results->isExpired());
-    }
 }

--- a/test/unit/ResultsTest.php
+++ b/test/unit/ResultsTest.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * This file is part of Lcobucci\JWT, a simple library to handle JWT and JWS
+ *
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ */
+
+namespace Lcobucci\JWT;
+
+use Lcobucci\JWT\Validation\Results;
+
+class ResultsTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     *
+     * @uses Lcobucci\JWT\Validator::__construct
+     *
+     * @covers Lcobucci\JWT\Validation\Results::errors
+     */
+    public function resultsShouldBeEmptyOnCreation()
+    {
+        $results = new Results();
+        $this->assertEmpty($results->errors());
+    }
+
+    /**
+     * @test
+     *
+     * @uses Lcobucci\JWT\Validator::__construct
+     *
+     * @covers Lcobucci\JWT\Validation\Results::valid
+     */
+    public function resultsShouldBeValidOnNoErrors()
+    {
+        $results = new Results();
+        $this->assertTrue($results->valid());
+    }
+
+    /**
+     * @test
+     *
+     * @uses Lcobucci\JWT\Validator::__construct
+     *
+     * @covers Lcobucci\JWT\Validation\Results::addError
+     * @covers Lcobucci\JWT\Validation\Results::valid
+     */
+    public function resultsShouldBeInvalidOnErrors()
+    {
+        $results = new Results();
+        $results->addError('iss', 'Value is not valid');
+
+        $errors = $results->errors();
+        $this->assertFalse($results->valid());
+        $this->assertArrayHasKey('iss', $results->errors());
+        $this->assertEquals('Value is not valid', $errors['iss']);
+    }
+
+    /**
+     * @test
+     *
+     * @uses Lcobucci\JWT\Validator::__construct
+     *
+     * @covers Lcobucci\JWT\Validation\Results::addError
+     * @covers Lcobucci\JWT\Validation\Results::valid
+     */
+    public function isExpiredShouldReturnTrueIfExpErrorIsSet()
+    {
+        $results = new Results();
+        $results->addError('exp', 'Expired');
+
+        $errors = $results->errors();
+        $this->assertFalse($results->valid());
+        $this->assertArrayHasKey('exp', $results->errors());
+        $this->assertEquals('Expired', $errors['exp']);
+        $this->assertTrue($results->isExpired());
+    }
+}

--- a/test/unit/ResultsTest.php
+++ b/test/unit/ResultsTest.php
@@ -7,6 +7,7 @@
 
 namespace Lcobucci\JWT;
 
+use Lcobucci\JWT\Exception\InvalidClaimException;
 use Lcobucci\JWT\Validation\Results;
 
 class ResultsTest extends \PHPUnit_Framework_TestCase
@@ -48,7 +49,7 @@ class ResultsTest extends \PHPUnit_Framework_TestCase
     public function resultsShouldBeInvalidOnErrors()
     {
         $results = new Results();
-        $results->addError('iss', 'Value is not valid');
+        $results->addError(new InvalidClaimException('iss', 'Value is not valid'));
 
         $errors = $results->getErrors();
         $this->assertFalse($results->isValid());

--- a/test/unit/ResultsTest.php
+++ b/test/unit/ResultsTest.php
@@ -21,7 +21,7 @@ class ResultsTest extends \PHPUnit_Framework_TestCase
     public function resultsShouldBeEmptyOnCreation()
     {
         $results = new Results();
-        $this->assertEmpty($results->errors());
+        $this->assertEmpty($results->getErrors());
     }
 
     /**
@@ -34,7 +34,7 @@ class ResultsTest extends \PHPUnit_Framework_TestCase
     public function resultsShouldBeValidOnNoErrors()
     {
         $results = new Results();
-        $this->assertTrue($results->valid());
+        $this->assertTrue($results->isValid());
     }
 
     /**
@@ -50,9 +50,9 @@ class ResultsTest extends \PHPUnit_Framework_TestCase
         $results = new Results();
         $results->addError('iss', 'Value is not valid');
 
-        $errors = $results->errors();
-        $this->assertFalse($results->valid());
-        $this->assertArrayHasKey('iss', $results->errors());
+        $errors = $results->getErrors();
+        $this->assertFalse($results->isValid());
+        $this->assertArrayHasKey('iss', $results->getErrors());
         $this->assertEquals('Value is not valid', $errors['iss']);
     }
 
@@ -69,9 +69,9 @@ class ResultsTest extends \PHPUnit_Framework_TestCase
         $results = new Results();
         $results->addError('exp', 'Expired');
 
-        $errors = $results->errors();
-        $this->assertFalse($results->valid());
-        $this->assertArrayHasKey('exp', $results->errors());
+        $errors = $results->getErrors();
+        $this->assertFalse($results->isValid());
+        $this->assertArrayHasKey('exp', $results->getErrors());
         $this->assertEquals('Expired', $errors['exp']);
         $this->assertTrue($results->isExpired());
     }

--- a/test/unit/TokenTest.php
+++ b/test/unit/TokenTest.php
@@ -315,9 +315,11 @@ class TokenTest extends \PHPUnit_Framework_TestCase
     public function validateShouldReturnTrueWhenClaimsAreEmpty()
     {
         $token = new Token();
-        $validator = new Validator();
+        $validator = new Validator(new ValidationData());
 
-        $this->assertTrue($validator->validate($token, new ValidationData()));
+        $results = $validator->validate($token);
+        $this->assertInstanceOf('\\Lcobucci\\JWT\\Validation\\ResultsInterface', $results);
+        $this->assertTrue($results->valid());
     }
 
     /**
@@ -333,9 +335,11 @@ class TokenTest extends \PHPUnit_Framework_TestCase
     public function validateShouldReturnTrueWhenThereAreNoValidatableClaims()
     {
         $token = new Token([], ['testing' => new Basic('testing', 'test')]);
-        $validator = new Validator();
+        $validator = new Validator(new ValidationData());
 
-        $this->assertTrue($validator->validate($token, new ValidationData()));
+        $results = $validator->validate($token);
+        $this->assertInstanceOf('\\Lcobucci\\JWT\\Validation\\ResultsInterface', $results);
+        $this->assertTrue($results->valid());
     }
 
     /**
@@ -359,11 +363,14 @@ class TokenTest extends \PHPUnit_Framework_TestCase
             ]
         );
 
-        $validator = new Validator();
         $data = new ValidationData();
         $data->setIssuer('test1');
+        $validator = new Validator($data);
 
-        $this->assertFalse($validator->validate($token, $data));
+        $results = $validator->validate($token);
+        $this->assertInstanceOf('\\Lcobucci\\JWT\\Validation\\ResultsInterface', $results);
+        $this->assertFalse($results->valid());
+        $this->assertArrayHasKey('iss', $results->errors());
     }
 
     /**
@@ -392,11 +399,13 @@ class TokenTest extends \PHPUnit_Framework_TestCase
             ]
         );
 
-        $validator = new Validator();
         $data = new ValidationData($now + 10);
         $data->setIssuer('test');
+        $validator = new Validator($data);
 
-        $this->assertTrue($validator->validate($token, $data));
+        $results = $validator->validate($token);
+        $this->assertInstanceOf('\\Lcobucci\\JWT\\Validation\\ResultsInterface', $results);
+        $this->assertTrue($results->valid());
     }
 
     /**

--- a/test/unit/TokenTest.php
+++ b/test/unit/TokenTest.php
@@ -318,8 +318,8 @@ class TokenTest extends \PHPUnit_Framework_TestCase
         $validator = new Validator(new ValidationData());
 
         $results = $validator->validate($token);
-        $this->assertInstanceOf('\\Lcobucci\\JWT\\Validation\\ResultsInterface', $results);
-        $this->assertTrue($results->valid());
+        $this->assertInstanceOf('\\Lcobucci\\JWT\\Validation\\ResultInterface', $results);
+        $this->assertTrue($results->isValid());
     }
 
     /**
@@ -338,8 +338,8 @@ class TokenTest extends \PHPUnit_Framework_TestCase
         $validator = new Validator(new ValidationData());
 
         $results = $validator->validate($token);
-        $this->assertInstanceOf('\\Lcobucci\\JWT\\Validation\\ResultsInterface', $results);
-        $this->assertTrue($results->valid());
+        $this->assertInstanceOf('\\Lcobucci\\JWT\\Validation\\ResultInterface', $results);
+        $this->assertTrue($results->isValid());
     }
 
     /**
@@ -368,9 +368,9 @@ class TokenTest extends \PHPUnit_Framework_TestCase
         $validator = new Validator($data);
 
         $results = $validator->validate($token);
-        $this->assertInstanceOf('\\Lcobucci\\JWT\\Validation\\ResultsInterface', $results);
-        $this->assertFalse($results->valid());
-        $this->assertArrayHasKey('iss', $results->errors());
+        $this->assertInstanceOf('\\Lcobucci\\JWT\\Validation\\ResultInterface', $results);
+        $this->assertFalse($results->isValid());
+        $this->assertArrayHasKey('iss', $results->getErrors());
     }
 
     /**
@@ -404,8 +404,8 @@ class TokenTest extends \PHPUnit_Framework_TestCase
         $validator = new Validator($data);
 
         $results = $validator->validate($token);
-        $this->assertInstanceOf('\\Lcobucci\\JWT\\Validation\\ResultsInterface', $results);
-        $this->assertTrue($results->valid());
+        $this->assertInstanceOf('\\Lcobucci\\JWT\\Validation\\ResultInterface', $results);
+        $this->assertTrue($results->isValid());
     }
 
     /**

--- a/test/unit/TokenTest.php
+++ b/test/unit/TokenTest.php
@@ -315,8 +315,9 @@ class TokenTest extends \PHPUnit_Framework_TestCase
     public function validateShouldReturnTrueWhenClaimsAreEmpty()
     {
         $token = new Token();
+        $validator = new Validator();
 
-        $this->assertTrue($token->validate(new ValidationData()));
+        $this->assertTrue($validator->validate($token, new ValidationData()));
     }
 
     /**
@@ -332,8 +333,9 @@ class TokenTest extends \PHPUnit_Framework_TestCase
     public function validateShouldReturnTrueWhenThereAreNoValidatableClaims()
     {
         $token = new Token([], ['testing' => new Basic('testing', 'test')]);
+        $validator = new Validator();
 
-        $this->assertTrue($token->validate(new ValidationData()));
+        $this->assertTrue($validator->validate($token, new ValidationData()));
     }
 
     /**
@@ -357,10 +359,11 @@ class TokenTest extends \PHPUnit_Framework_TestCase
             ]
         );
 
+        $validator = new Validator();
         $data = new ValidationData();
         $data->setIssuer('test1');
 
-        $this->assertFalse($token->validate($data));
+        $this->assertFalse($validator->validate($token, $data));
     }
 
     /**
@@ -389,10 +392,11 @@ class TokenTest extends \PHPUnit_Framework_TestCase
             ]
         );
 
+        $validator = new Validator();
         $data = new ValidationData($now + 10);
         $data->setIssuer('test');
 
-        $this->assertTrue($token->validate($data));
+        $this->assertTrue($validator->validate($token, $data));
     }
 
     /**

--- a/test/unit/ValidatorTest.php
+++ b/test/unit/ValidatorTest.php
@@ -24,8 +24,8 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $token = $this->getToken(['iss' => 'test']);
         $data = $this->getValidationData();
 
-        $validator = new Validator();
-        $this->assertTrue($validator->validate($token, $data));
+        $validator = new Validator($data);
+        $this->assertInstanceOf('\\Lcobucci\\JWT\\Validation\\ResultsInterface', $validator->validate($token));
     }
 
     /**
@@ -35,13 +35,14 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
      *
      * @covers Lcobucci\JWT\Validator::validate
      */
-    public function validatorShouldReturnFalseOnErrors()
+    public function validatorResultsShouldReturnFalseOnErrors()
     {
         $token = $this->getToken(['iss' => 'tester']);
         $data = $this->getValidationData();
 
-        $validator = new Validator();
-        $this->assertFalse($validator->validate($token, $data));
+        $validator = new Validator($data);
+        $results = $validator->validate($token);
+        $this->assertFalse($results->valid());
     }
 
     /**
@@ -56,9 +57,11 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $token = $this->getToken(['iss' => 'tester']);
         $data = $this->getValidationData();
 
-        $validator = new Validator();
-        $this->assertFalse($validator->validate($token, $data));
-        $this->assertEquals(['iss' => false], $validator->getErrors());
+        $validator = new Validator($data);
+        $results = $validator->validate($token);
+        $this->assertInstanceOf('\\Lcobucci\\JWT\\Validation\\ResultsInterface', $results);
+        $this->assertFalse($results->valid());
+        $this->assertArrayHasKey('iss', $results->errors());
     }
 
     public function getValidationData()

--- a/test/unit/ValidatorTest.php
+++ b/test/unit/ValidatorTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * This file is part of Lcobucci\JWT, a simple library to handle JWT and JWS
+ *
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ */
+
+namespace Lcobucci\JWT;
+
+/**
+ * @author Danny Dörfel <danny.dorfel@gmail.com>
+ */
+class ValidatorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     *
+     * @uses Lcobucci\JWT\Validator::__construct
+     *
+     * @covers Lcobucci\JWT\Validator::validate
+     */
+    public function validateShouldValidateTheData()
+    {
+        $token = $this->getToken(['iss' => 'test']);
+        $data = $this->getValidationData();
+
+        $validator = new Validator();
+        $this->assertTrue($validator->validate($token, $data));
+    }
+
+    /**
+     * @test
+     *
+     * @uses Lcobucci\JWT\Validator::__construct
+     *
+     * @covers Lcobucci\JWT\Validator::validate
+     */
+    public function validatorShouldReturnFalseOnErrors()
+    {
+        $token = $this->getToken(['iss' => 'tester']);
+        $data = $this->getValidationData();
+
+        $validator = new Validator();
+        $this->assertFalse($validator->validate($token, $data));
+    }
+
+    /**
+     * @test
+     *
+     * @uses Lcobucci\JWT\Validator::__construct
+     *
+     * @covers Lcobucci\JWT\Validator::getErrors
+     */
+    public function validatorShouldHaveErrors()
+    {
+        $token = $this->getToken(['iss' => 'tester']);
+        $data = $this->getValidationData();
+
+        $validator = new Validator();
+        $this->assertFalse($validator->validate($token, $data));
+        $this->assertEquals(['iss' => false], $validator->getErrors());
+    }
+
+    public function getValidationData()
+    {
+        $data = new ValidationData(1);
+        $data->setIssuer('test');
+
+        return $data;
+    }
+
+    public function getToken($claims)
+    {
+        $builder = new Builder();
+
+        foreach ($claims as $claim => $value) {
+            $builder->set($claim, $value);
+        }
+
+        return $builder->getToken();
+    }
+}

--- a/test/unit/ValidatorTest.php
+++ b/test/unit/ValidatorTest.php
@@ -25,7 +25,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $data = $this->getValidationData();
 
         $validator = new Validator($data);
-        $this->assertInstanceOf('\\Lcobucci\\JWT\\Validation\\ResultsInterface', $validator->validate($token));
+        $this->assertInstanceOf('\\Lcobucci\\JWT\\Validation\\ResultInterface', $validator->validate($token));
     }
 
     /**
@@ -42,7 +42,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 
         $validator = new Validator($data);
         $results = $validator->validate($token);
-        $this->assertFalse($results->valid());
+        $this->assertFalse($results->isValid());
     }
 
     /**
@@ -59,9 +59,9 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 
         $validator = new Validator($data);
         $results = $validator->validate($token);
-        $this->assertInstanceOf('\\Lcobucci\\JWT\\Validation\\ResultsInterface', $results);
-        $this->assertFalse($results->valid());
-        $this->assertArrayHasKey('iss', $results->errors());
+        $this->assertInstanceOf('\\Lcobucci\\JWT\\Validation\\ResultInterface', $results);
+        $this->assertFalse($results->isValid());
+        $this->assertArrayHasKey('iss', $results->getErrors());
     }
 
     public function getValidationData()


### PR DESCRIPTION
@lcobucci I kept the responsibility for validating in the claim, since they are like value objects and know best how to validate themselves. I'm not sure where to put the error message. In the claim itself? 

Also documentation still needs update in this PR. 

Your comments please?