### PR TITLE
Allow arrays or audience claim and issuer validation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,19 @@ echo $token->getClaim('uid'); // will print "1"
 echo $token; // The string representation of the object is a JWT string (pretty easy, right?)
 ```
 
+If we have multiple possible members in the audience of a given token, we can set multiple audience members like so:
+
+```php
+$token = (new Builder())->setIssuer('http://example.com')
+                        ->setAudience(['http://example.org', 'http://example.com', 'http://example.io']) // Sets all three as audience members of this token.
+                        ->setId('4f1g23a12aa', true)
+                        ->setIssuedAt(time())
+                        ->setNotBefore(time() + 60)
+                        ->setExpiration(time() + 3600)
+                        ->set('uid', 1)
+                        ->getToken();
+```
+
 ### Parsing from strings
 
 Use the parser to create a new token from a JWT string (using the previous token as example):
@@ -66,7 +79,7 @@ $token->getHeaders(); // Retrieves the token header
 $token->getClaims(); // Retrieves the token claims
 
 echo $token->getHeader('jti'); // will print "4f1g23a12aa"
-echo $token->getClaim('iss'); // will print "http://example.com"
+echo $token->getClaim('iss')[0]; // will print "http://example.org"
 echo $token->getClaim('uid'); // will print "1"
 ```
 
@@ -87,6 +100,14 @@ var_dump($token->validate($data)); // true, because validation information is eq
 $data->setCurrentTime(time() + 4000); // changing the validation time to future
 
 var_dump($token->validate($data)); // false, because token is expired since current time is greater than exp
+```
+
+If we have multiple possible issuers of an equivalent token, then it is possible to set multiple issuers to the ```ValidationData``` object:
+
+```php
+$data = new ValidationData();
+$data->setIssuer(['http://example.com', 'http://example.io']);
+$data->setAudience('http://example.org');
 ```
 
 #### Important

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -76,14 +76,21 @@ class Builder
     /**
      * Configures the audience
      *
-     * @param string $audience
+     * @param string|array $audience
      * @param bool $replicateAsHeader
      *
      * @return Builder
      */
-    public function setAudience(string $audience, bool $replicateAsHeader = false): Builder
+    public function setAudience($audience, bool $replicateAsHeader = false): Builder
     {
-        return $this->setRegisteredClaim('aud', $audience, $replicateAsHeader);
+        if (is_array($audience)) {
+            foreach($audience as $key => $member) {
+                $audience[$key] = (string) $member;
+            }
+            return $this->setRegisteredClaim('aud', $audience, $replicateAsHeader);
+        } else {
+            return $this->setRegisteredClaim('aud', [(string) $audience], $replicateAsHeader);
+        }
     }
 
     /**
@@ -201,7 +208,7 @@ class Builder
         }
 
         $this->headers[$name] = $this->claimFactory->create($name, $value);
-
+        
         return $this;
     }
 

--- a/src/Claim/ContainedEqualsTo.php
+++ b/src/Claim/ContainedEqualsTo.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * This file is part of Lcobucci\JWT, a simple library to handle JWT and JWS
+ *
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ */
+
+declare(strict_types=1);
+
+namespace Lcobucci\JWT\Claim;
+
+use Lcobucci\JWT\Claim;
+use Lcobucci\JWT\ValidationData;
+
+/**
+ * Validatable claim that checks if claim value is strictly equal to an item in the given validation data set.
+ *
+ * @author Matthew John Marshall <matthew.marshall96@yahoo.co.uk>
+ * @since x.x.x
+ */
+class ContainedEqualsTo extends Basic implements Claim, Validatable
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function validate(ValidationData $data) : bool
+    {
+        if ($data->has($this->getName())) {
+            foreach ($data->get($this->getName()) as $validationValue) {
+                if ($this->getValue() === $validationValue) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/Claim/ContainsEqualsTo.php
+++ b/src/Claim/ContainsEqualsTo.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * This file is part of Lcobucci\JWT, a simple library to handle JWT and JWS
+ *
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ */
+
+declare(strict_types=1);
+
+namespace Lcobucci\JWT\Claim;
+
+use Lcobucci\JWT\Claim;
+use Lcobucci\JWT\ValidationData;
+
+/**
+ * Validatable claim that checks if the claim value set contains a value strictly equal to the validation item value.
+ *
+ * @author Matthew John Marshall <matthew.marshall96@yahoo.co.uk>
+ * @since x.x.x
+ */
+class ContainsEqualsTo extends Basic implements Claim, Validatable
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function validate(ValidationData $data) : bool
+    {
+        if ($data->has($this->getName())) {
+            foreach ($this->getValue() as $claimValue) {
+                if ($claimValue === $data->get($this->getName())) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/Claim/Factory.php
+++ b/src/Claim/Factory.php
@@ -38,8 +38,8 @@ class Factory
                 'iat' => [$this, 'createLesserOrEqualsTo'],
                 'nbf' => [$this, 'createLesserOrEqualsTo'],
                 'exp' => [$this, 'createGreaterOrEqualsTo'],
-                'iss' => [$this, 'createEqualsTo'],
-                'aud' => [$this, 'createEqualsTo'],
+                'iss' => [$this, 'createContainedEqualsTo'],
+                'aud' => [$this, 'createContainsEqualsTo'],
                 'sub' => [$this, 'createEqualsTo'],
                 'jti' => [$this, 'createEqualsTo']
             ],
@@ -101,6 +101,32 @@ class Factory
     private function createEqualsTo(string $name, $value): EqualsTo
     {
         return new EqualsTo($name, $value);
+    }
+
+    /**
+     * Creates a claim that can be compared (contained equals).
+     *
+     * @param string $name
+     * @param mixed $value
+     *
+     * @return ContainedEqualsTo
+     */
+    protected function createContainedEqualsTo(string $name, $value): ContainedEqualsTo
+    {
+        return new ContainedEqualsTo($name, $value);
+    }
+
+    /**
+     * Creates a claim that can be compared (contains equals).
+     *
+     * @param string $name
+     * @param mixed $value
+     *
+     * @return ContainsEqualsTo
+     */
+    protected function createContainsEqualsTo(string $name, $value): ContainsEqualsTo
+    {
+        return new ContainsEqualsTo($name, $value);
     }
 
     /**

--- a/src/ValidationData.php
+++ b/src/ValidationData.php
@@ -57,11 +57,18 @@ class ValidationData
     /**
      * Configures the issuer
      *
-     * @param string $issuer
+     * @param string|array $issuer
      */
-    public function setIssuer(string $issuer)
+    public function setIssuer($issuer)
     {
-        $this->items['iss'] = $issuer;
+        if (is_array($issuer)) {
+            foreach($issuer as $key => $member) {
+                $issuer[$key] = (string) $member;
+            }
+            $this->items['iss'] = $issuer;
+        } else {
+            $this->items['iss'] = [(string) $issuer];
+        }
     }
 
     /**

--- a/test/functional/EcdsaTokenTest.php
+++ b/test/functional/EcdsaTokenTest.php
@@ -93,7 +93,7 @@ class EcdsaTokenTest extends \PHPUnit_Framework_TestCase
 
         $this->assertAttributeInstanceOf(Signature::class, 'signature', $token);
         $this->assertEquals('1234', $token->getHeader('jki'));
-        $this->assertEquals('http://client.abc.com', $token->getClaim('aud'));
+        $this->assertEquals(['http://client.abc.com'], $token->getClaim('aud'));
         $this->assertEquals('http://api.abc.com', $token->getClaim('iss'));
         $this->assertEquals($user, $token->getClaim('user'));
 

--- a/test/functional/HmacTokenTest.php
+++ b/test/functional/HmacTokenTest.php
@@ -62,7 +62,7 @@ class HmacTokenTest extends \PHPUnit_Framework_TestCase
 
         $this->assertAttributeInstanceOf(Signature::class, 'signature', $token);
         $this->assertEquals('1234', $token->getHeader('jki'));
-        $this->assertEquals('http://client.abc.com', $token->getClaim('aud'));
+        $this->assertEquals(['http://client.abc.com'], $token->getClaim('aud'));
         $this->assertEquals('http://api.abc.com', $token->getClaim('iss'));
         $this->assertEquals($user, $token->getClaim('user'));
 

--- a/test/functional/RsaTokenTest.php
+++ b/test/functional/RsaTokenTest.php
@@ -89,7 +89,7 @@ class RsaTokenTest extends \PHPUnit_Framework_TestCase
 
         $this->assertAttributeInstanceOf(Signature::class, 'signature', $token);
         $this->assertEquals('1234', $token->getHeader('jki'));
-        $this->assertEquals('http://client.abc.com', $token->getClaim('aud'));
+        $this->assertEquals(['http://client.abc.com'], $token->getClaim('aud'));
         $this->assertEquals('http://api.abc.com', $token->getClaim('iss'));
         $this->assertEquals($user, $token->getClaim('user'));
 

--- a/test/functional/UnsignedTokenTest.php
+++ b/test/functional/UnsignedTokenTest.php
@@ -42,7 +42,7 @@ class UnsignedTokenTest extends \PHPUnit_Framework_TestCase
                               ->getToken();
 
         $this->assertAttributeEquals(null, 'signature', $token);
-        $this->assertEquals('http://client.abc.com', $token->getClaim('aud'));
+        $this->assertEquals(['http://client.abc.com'], $token->getClaim('aud'));
         $this->assertEquals('http://api.abc.com', $token->getClaim('iss'));
         $this->assertEquals(self::CURRENT_TIME + 3000, $token->getClaim('exp'));
         $this->assertEquals($user, $token->getClaim('user'));

--- a/test/unit/BuilderTest.php
+++ b/test/unit/BuilderTest.php
@@ -98,6 +98,24 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
      * @covers Lcobucci\JWT\Builder::setAudience
      * @covers Lcobucci\JWT\Builder::setRegisteredClaim
      */
+    public function setAudienceMustAcceptArrayOfValues()
+    {
+        $builder = $this->createBuilder();
+        $builder->setAudience(['test', 'test2']);
+
+        $this->assertAttributeEquals(['alg' => 'none', 'typ' => 'JWT'], 'headers', $builder);
+        $this->assertAttributeEquals(['aud' => $this->defaultClaim], 'claims', $builder);
+    }
+
+    /**
+     * @test
+     *
+     * @uses Lcobucci\JWT\Builder::__construct
+     * @uses Lcobucci\JWT\Builder::set
+     *
+     * @covers Lcobucci\JWT\Builder::setAudience
+     * @covers Lcobucci\JWT\Builder::setRegisteredClaim
+     */
     public function setAudienceCanReplicateItemOnHeader()
     {
         $builder = $this->createBuilder();

--- a/test/unit/Claim/ContainedEqualsToTest.php
+++ b/test/unit/Claim/ContainedEqualsToTest.php
@@ -12,10 +12,10 @@ namespace Lcobucci\JWT\Claim;
 use Lcobucci\JWT\ValidationData;
 
 /**
- * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
- * @since 2.0.0
+ * @author Matthew John Marshall <matthew.marshall96@yahoo.co.uk>
+ * @since x.x.x
  */
-class LesserOrEqualsToTest extends \PHPUnit_Framework_TestCase
+class ContainedEqualsToTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @test
@@ -25,11 +25,11 @@ class LesserOrEqualsToTest extends \PHPUnit_Framework_TestCase
      * @uses Lcobucci\JWT\ValidationData::__construct
      * @uses Lcobucci\JWT\ValidationData::has
      *
-     * @covers Lcobucci\JWT\Claim\LesserOrEqualsTo::validate
+     * @covers Lcobucci\JWT\Claim\ContainedEqualsTo::validate
      */
-    public function validateShouldReturnTrueWhenValidationDontHaveTheClaim()
+    public function validateShouldReturnTrueWhenValidationDoesntHaveTheClaim()
     {
-        $claim = new LesserOrEqualsTo('jti', 10);
+        $claim = new ContainedEqualsTo('iss', 'test');
 
         $this->assertTrue($claim->validate(new ValidationData()));
     }
@@ -45,12 +45,14 @@ class LesserOrEqualsToTest extends \PHPUnit_Framework_TestCase
      * @uses Lcobucci\JWT\ValidationData::has
      * @uses Lcobucci\JWT\ValidationData::get
      *
-     * @covers Lcobucci\JWT\Claim\LesserOrEqualsTo::validate
+     * @covers Lcobucci\JWT\Claim\ContainedEqualsTo::validate
      */
-    public function validateShouldReturnTrueWhenValueIsLesserThanValidationData()
+    public function validateShouldReturnTrueWhenClaimValueIsEqualToAtLeastOneItemInValidationData()
     {
-        $claim = new LesserOrEqualsTo('iat', 10);
-        $data = new ValidationData(11);
+        $claim = new ContainedEqualsTo('iss', 'test');
+
+        $data = new ValidationData();
+        $data->setIssuer(['test', 'test2']);
 
         $this->assertTrue($claim->validate($data));
     }
@@ -66,33 +68,14 @@ class LesserOrEqualsToTest extends \PHPUnit_Framework_TestCase
      * @uses Lcobucci\JWT\ValidationData::has
      * @uses Lcobucci\JWT\ValidationData::get
      *
-     * @covers Lcobucci\JWT\Claim\LesserOrEqualsTo::validate
+     * @covers Lcobucci\JWT\Claim\ContainedEqualsTo::validate
      */
-    public function validateShouldReturnTrueWhenValueIsEqualsToValidationData()
+    public function validateShouldReturnFalseWhenClaimValueIsNotEqualToAtLeastOneItemInValidationData()
     {
-        $claim = new LesserOrEqualsTo('iat', 10);
-        $data = new ValidationData(10);
+        $claim = new ContainedEqualsTo('iss', 'test');
 
-        $this->assertTrue($claim->validate($data));
-    }
-
-    /**
-     * @test
-     *
-     * @uses Lcobucci\JWT\Claim\Basic::__construct
-     * @uses Lcobucci\JWT\Claim\Basic::getName
-     * @uses Lcobucci\JWT\Claim\Basic::getValue
-     * @uses Lcobucci\JWT\ValidationData::__construct
-     * @uses Lcobucci\JWT\ValidationData::setIssuer
-     * @uses Lcobucci\JWT\ValidationData::has
-     * @uses Lcobucci\JWT\ValidationData::get
-     *
-     * @covers Lcobucci\JWT\Claim\LesserOrEqualsTo::validate
-     */
-    public function validateShouldReturnFalseWhenValueIsGreaterThanValidationData()
-    {
-        $claim = new LesserOrEqualsTo('iat', 11);
-        $data = new ValidationData(10);
+        $data = new ValidationData();
+        $data->setIssuer(['test2', 'test3']);
 
         $this->assertFalse($claim->validate($data));
     }

--- a/test/unit/Claim/ContainsEqualsToTest.php
+++ b/test/unit/Claim/ContainsEqualsToTest.php
@@ -12,10 +12,10 @@ namespace Lcobucci\JWT\Claim;
 use Lcobucci\JWT\ValidationData;
 
 /**
- * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
- * @since 2.0.0
+ * @author Matthew John Marshall <matthew.marshall96@yahoo.co.uk>
+ * @since x.x.x
  */
-class LesserOrEqualsToTest extends \PHPUnit_Framework_TestCase
+class ContainsEqualsToTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @test
@@ -25,11 +25,11 @@ class LesserOrEqualsToTest extends \PHPUnit_Framework_TestCase
      * @uses Lcobucci\JWT\ValidationData::__construct
      * @uses Lcobucci\JWT\ValidationData::has
      *
-     * @covers Lcobucci\JWT\Claim\LesserOrEqualsTo::validate
+     * @covers Lcobucci\JWT\Claim\ContainsEqualsTo::validate
      */
-    public function validateShouldReturnTrueWhenValidationDontHaveTheClaim()
+    public function validateShouldReturnTrueWhenValidationDoesntHaveTheClaim()
     {
-        $claim = new LesserOrEqualsTo('jti', 10);
+        $claim = new ContainsEqualsTo('aud', ['test', 'test2']);
 
         $this->assertTrue($claim->validate(new ValidationData()));
     }
@@ -45,12 +45,14 @@ class LesserOrEqualsToTest extends \PHPUnit_Framework_TestCase
      * @uses Lcobucci\JWT\ValidationData::has
      * @uses Lcobucci\JWT\ValidationData::get
      *
-     * @covers Lcobucci\JWT\Claim\LesserOrEqualsTo::validate
+     * @covers Lcobucci\JWT\Claim\ContainsEqualsTo::validate
      */
-    public function validateShouldReturnTrueWhenValueIsLesserThanValidationData()
+    public function validateShouldReturnTrueWhenValidationDataValueIsContained()
     {
-        $claim = new LesserOrEqualsTo('iat', 10);
-        $data = new ValidationData(11);
+        $claim = new ContainsEqualsTo('aud', ['test', 'test2']);
+
+        $data = new ValidationData();
+        $data->setAudience('test');
 
         $this->assertTrue($claim->validate($data));
     }
@@ -66,33 +68,14 @@ class LesserOrEqualsToTest extends \PHPUnit_Framework_TestCase
      * @uses Lcobucci\JWT\ValidationData::has
      * @uses Lcobucci\JWT\ValidationData::get
      *
-     * @covers Lcobucci\JWT\Claim\LesserOrEqualsTo::validate
+     * @covers Lcobucci\JWT\Claim\ContainsEqualsTo::validate
      */
-    public function validateShouldReturnTrueWhenValueIsEqualsToValidationData()
+    public function validateShouldReturnFalseWhenValidationDataValueIsNotContained()
     {
-        $claim = new LesserOrEqualsTo('iat', 10);
-        $data = new ValidationData(10);
+        $claim = new EqualsTo('aud', ['test', 'test2']);
 
-        $this->assertTrue($claim->validate($data));
-    }
-
-    /**
-     * @test
-     *
-     * @uses Lcobucci\JWT\Claim\Basic::__construct
-     * @uses Lcobucci\JWT\Claim\Basic::getName
-     * @uses Lcobucci\JWT\Claim\Basic::getValue
-     * @uses Lcobucci\JWT\ValidationData::__construct
-     * @uses Lcobucci\JWT\ValidationData::setIssuer
-     * @uses Lcobucci\JWT\ValidationData::has
-     * @uses Lcobucci\JWT\ValidationData::get
-     *
-     * @covers Lcobucci\JWT\Claim\LesserOrEqualsTo::validate
-     */
-    public function validateShouldReturnFalseWhenValueIsGreaterThanValidationData()
-    {
-        $claim = new LesserOrEqualsTo('iat', 11);
-        $data = new ValidationData(10);
+        $data = new ValidationData();
+        $data->setAudience('test3');
 
         $this->assertFalse($claim->validate($data));
     }

--- a/test/unit/Claim/EqualsToTest.php
+++ b/test/unit/Claim/EqualsToTest.php
@@ -29,7 +29,7 @@ class EqualsToTest extends \PHPUnit_Framework_TestCase
      */
     public function validateShouldReturnTrueWhenValidationDontHaveTheClaim()
     {
-        $claim = new EqualsTo('iss', 'test');
+        $claim = new EqualsTo('sub', 'test');
 
         $this->assertTrue($claim->validate(new ValidationData()));
     }
@@ -49,10 +49,10 @@ class EqualsToTest extends \PHPUnit_Framework_TestCase
      */
     public function validateShouldReturnTrueWhenValueIsEqualsToValidationData()
     {
-        $claim = new EqualsTo('iss', 'test');
+        $claim = new EqualsTo('sub', 'test');
 
         $data = new ValidationData();
-        $data->setIssuer('test');
+        $data->setSubject('test');
 
         $this->assertTrue($claim->validate($data));
     }
@@ -72,10 +72,10 @@ class EqualsToTest extends \PHPUnit_Framework_TestCase
      */
     public function validateShouldReturnFalseWhenValueIsNotEqualsToValidationData()
     {
-        $claim = new EqualsTo('iss', 'test');
+        $claim = new EqualsTo('sub', 'test');
 
         $data = new ValidationData();
-        $data->setIssuer('test1');
+        $data->setSubject('test1');
 
         $this->assertFalse($claim->validate($data));
     }

--- a/test/unit/Claim/FactoryTest.php
+++ b/test/unit/Claim/FactoryTest.php
@@ -30,8 +30,8 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
             'iat' => [$factory, 'createLesserOrEqualsTo'],
             'nbf' => [$factory, 'createLesserOrEqualsTo'],
             'exp' => [$factory, 'createGreaterOrEqualsTo'],
-            'iss' => [$factory, 'createEqualsTo'],
-            'aud' => [$factory, 'createEqualsTo'],
+            'iss' => [$factory, 'createContainedEqualsTo'],
+            'aud' => [$factory, 'createContainsEqualsTo'],
             'sub' => [$factory, 'createEqualsTo'],
             'jti' => [$factory, 'createEqualsTo'],
             'test' => $callback
@@ -111,13 +111,13 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
      * @uses Lcobucci\JWT\Claim\Basic::__construct
      *
      * @covers Lcobucci\JWT\Claim\Factory::create
-     * @covers Lcobucci\JWT\Claim\Factory::createEqualsTo
+     * @covers Lcobucci\JWT\Claim\Factory::createContainedEqualsTo
      */
-    public function createShouldReturnAnEqualsToClaimForIssuer()
+    public function createShouldReturnAContainedEqualsToClaimForIssuer()
     {
         $claim = new Factory();
 
-        $this->assertInstanceOf(EqualsTo::class, $claim->create('iss', 1));
+        $this->assertInstanceOf(ContainedEqualsTo::class, $claim->create('iss', 1));
     }
 
     /**
@@ -127,13 +127,13 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
      * @uses Lcobucci\JWT\Claim\Basic::__construct
      *
      * @covers Lcobucci\JWT\Claim\Factory::create
-     * @covers Lcobucci\JWT\Claim\Factory::createEqualsTo
+     * @covers Lcobucci\JWT\Claim\Factory::createContainsEqualsTo
      */
-    public function createShouldReturnAnEqualsToClaimForAudience()
+    public function createShouldReturnAContainsEqualsToClaimForAudience()
     {
         $claim = new Factory();
 
-        $this->assertInstanceOf(EqualsTo::class, $claim->create('aud', 1));
+        $this->assertInstanceOf(ContainsEqualsTo::class, $claim->create('aud', 1));
     }
 
     /**

--- a/test/unit/Claim/GreaterOrEqualsToTest.php
+++ b/test/unit/Claim/GreaterOrEqualsToTest.php
@@ -29,7 +29,7 @@ class GreaterOrEqualsToTest extends \PHPUnit_Framework_TestCase
      */
     public function validateShouldReturnTrueWhenValidationDontHaveTheClaim()
     {
-        $claim = new GreaterOrEqualsTo('iss', 10);
+        $claim = new GreaterOrEqualsTo('jti', 10);
 
         $this->assertTrue($claim->validate(new ValidationData()));
     }

--- a/test/unit/TokenTest.php
+++ b/test/unit/TokenTest.php
@@ -13,6 +13,8 @@ use Lcobucci\JWT\Claim\Basic;
 use Lcobucci\JWT\Claim\EqualsTo;
 use Lcobucci\JWT\Claim\GreaterOrEqualsTo;
 use Lcobucci\JWT\Claim\LesserOrEqualsTo;
+use Lcobucci\JWT\Claim\ContainedEqualsTo;
+use Lcobucci\JWT\Claim\ContainsEqualsTo;
 
 /**
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
@@ -87,6 +89,7 @@ class TokenTest extends \PHPUnit_Framework_TestCase
      * @uses Lcobucci\JWT\Token::hasHeader
      *
      * @covers Lcobucci\JWT\Token::getHeader
+     * @covers Lcobucci\JWT\Token::getHeaderValue
      */
     public function getHeaderMustReturnTheDefaultValueWhenIsNotConfigured()
     {
@@ -382,7 +385,7 @@ class TokenTest extends \PHPUnit_Framework_TestCase
         $token = new Token(
             [],
             [
-                'iss' => new EqualsTo('iss', 'test'),
+                'iss' => new ContainedEqualsTo('iss', 'test'),
                 'iat' => new LesserOrEqualsTo('iat', $now),
                 'exp' => new GreaterOrEqualsTo('ext', $now + 500),
                 'testing' => new Basic('testing', 'test')

--- a/test/unit/ValidationDataTest.php
+++ b/test/unit/ValidationDataTest.php
@@ -65,6 +65,22 @@ class ValidationDataTest extends \PHPUnit_Framework_TestCase
      *
      * @uses Lcobucci\JWT\ValidationData::__construct
      *
+     * @covers Lcobucci\JWT\ValidationData::setIssuer
+     */
+    public function setIssuerMustAcceptArrayOfValues()
+    {
+        $expected = $this->createExpectedData(null, null, ['test', 'test2']);
+        $data = new ValidationData(1);
+        $data->setIssuer(['test', 'test2']);
+
+        $this->assertAttributeSame($expected, 'items', $data);
+    }
+
+    /**
+     * @test
+     *
+     * @uses Lcobucci\JWT\ValidationData::__construct
+     *
      * @covers Lcobucci\JWT\ValidationData::setAudience
      */
     public function setAudienceShouldChangeTheAudience()
@@ -188,17 +204,23 @@ class ValidationDataTest extends \PHPUnit_Framework_TestCase
      * @return array
      */
     private function createExpectedData(
-        string $id = null,
-        string $sub = null,
-        string $iss = null,
-        string $aud = null,
-        int $time = 1
-    ): array {
+        $id = null,
+        $sub = null,
+        $iss = null,
+        $aud = null,
+        $time = 1
+    ) {
+        if ($iss !== null) {
+            $iss = (array) $iss;
+            foreach ($iss as $key => $member) {
+                $iss[$key] = (string) $member;
+            }
+        }
         return [
-            'jti' => $id,
+            'jti' => $id !== null ? (string) $id : null,
             'iss' => $iss,
-            'aud' => $aud,
-            'sub' => $sub,
+            'aud' => $aud !== null ? (string) $aud : null,
+            'sub' => $sub !== null ? (string) $sub : null,
             'iat' => $time,
             'nbf' => $time,
             'exp' => $time


### PR DESCRIPTION
I have synced into master and squashed commits as requested. :)

---

I have made changes that allow this JWT solution to follow more closely RFC7519 section 4.1.3 which allows for multiple audience members in the 'aud' claim via an array of stringOrUri values. Also follows the implications in section 4.1.7 of the same RFC which suggests that multiple issuers may be possible and acceptable for the same token - given the 'jti' claim can (should?) instead be used to differentiate tokens in circumstances where a set of issuers are considered equal.

The changes allow for uses like the following:

```php
$token = (new Builder())->setIssuer("http://example.com")
                        ->setAudience(["http://example.org", "http://example.com", "http://example.co.uk"])
                        ->setIssuedAt(time())
                        ->setNotBefore(time() + 60)
                        ->setExpiration(time() + 3600)
                        ->getToken();

$data = new ValidationData();
$data->setIssuer(["http://example.com", "http://example.org"]);
$data->setAudience("http://example.org");

var_dump($token->validate($data)); // True as the specified audience in ValidationData exists as a member of the 'aud' claim.
                                   // Also the 'iss' claim value is one of the values passed as allowed issuers to the ValidationData object.
```

Backwards compatibility is broken due to ```getAudience()``` in ```Builder``` and ```get("iss")``` in ```ValidationData```.

One issue is that it in the current system ```setIssuer``` would no longer be correctly named given multiple issuers are possible.