### PR TITLE
Don't use generators

### DIFF
--- a/src/Token.php
+++ b/src/Token.php
@@ -224,11 +224,14 @@ class Token
      */
     private function getValidatableClaims()
     {
+        $validatableClaims = array();
         foreach ($this->claims as $claim) {
             if ($claim instanceof Validatable) {
-                yield $claim;
+                $validatableClaims[] = $claim;
             }
         }
+
+        return $validatableClaims;
     }
 
     /**


### PR DESCRIPTION
As far as I can tell, this is the only thing making the library incompatible with PHP 5.4.

Being compatible with PHP 5.4 would be important to make the library usable in WordPress plugins, see for example: https://wordpress.org/support/topic/svn-commit-fails-because-of-yield-keyword.

Also, since generators aren't widely used in the 3.1 branch (just once), I don't see the advantage in depending on them.