### PR TITLE
Enable checking to see if tokens are expired

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -5,7 +5,7 @@ build:
         redis: false
         rabbitmq: false
         php:
-            version: 7.0
+            version: 7.0.8
 tools:
     php_sim: true
     php_pdepend: true

--- a/src/Token.php
+++ b/src/Token.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Lcobucci\JWT;
 
+use DateTime;
 use Generator;
 use Lcobucci\JWT\Claim\Validatable;
 use Lcobucci\JWT\Signer\Key;
@@ -211,6 +212,32 @@ class Token
         }
 
         return true;
+    }
+
+    /**
+     * Determine if the token is expired.
+     *
+     * @param DateTime $now Defaults to the current time.
+     *
+     * @return boolean
+     */
+    public function isExpired(DateTime $now = null)
+    {
+        $exp = $this->getClaim('exp', false);
+
+        if ($exp === false) {
+            // No expiration value, token never expires.
+            return false;
+        }
+
+        $expiresAt = new DateTime();
+        $expiresAt->setTimestamp($exp);
+
+        if ($now === null) {
+            $now = new DateTime();
+        }
+
+        return $now > $expiresAt;
     }
 
     /**

--- a/test/unit/TokenTest.php
+++ b/test/unit/TokenTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Lcobucci\JWT;
 
+use DateInterval;
+use DateTime;
 use Lcobucci\JWT\Claim\Basic;
 use Lcobucci\JWT\Claim\EqualsTo;
 use Lcobucci\JWT\Claim\GreaterOrEqualsTo;
@@ -384,7 +386,7 @@ class TokenTest extends \PHPUnit_Framework_TestCase
             [
                 'iss' => new EqualsTo('iss', 'test'),
                 'iat' => new LesserOrEqualsTo('iat', $now),
-                'exp' => new GreaterOrEqualsTo('ext', $now + 500),
+                'exp' => new GreaterOrEqualsTo('exp', $now + 500),
                 'testing' => new Basic('testing', 'test')
             ]
         );
@@ -393,6 +395,36 @@ class TokenTest extends \PHPUnit_Framework_TestCase
         $data->setIssuer('test');
 
         $this->assertTrue($token->validate($data));
+    }
+
+    /**
+     * @test
+     *
+     * @uses Lcobucci\JWT\Token::__construct
+     * @uses Lcobucci\JWT\Token::isExpired
+     * @uses Lcobucci\JWT\Claim\GreaterOrEqualsTo
+     *
+     * @covers Lcobucci\JWT\Token::isExpired
+     */
+    public function isExpiredShouldReturnTrueAfterTokenExpires()
+    {
+        $now = time();
+
+        $token = new Token(
+            [],
+            [
+                'exp' => new GreaterOrEqualsTo('exp', $now + 500),
+            ]
+        );
+
+        $this->assertFalse($token->isExpired());
+
+        // The value of "now" can also be overloaded to check if the token was
+        // expired at a specific point in time.
+        $date = new DateTime();
+        $date->add(new DateInterval('P10D'));
+
+        $this->assertTrue($token->isExpired($date));
     }
 
     /**


### PR DESCRIPTION
Being able to check if a token is expired without checking other claims
is sometimes necessary, eg when doing token refreshing.

Refs #108