### PR TITLE
Accepts DateTimeInterface since Immutable can also be used

### DIFF
--- a/src/Token.php
+++ b/src/Token.php
@@ -9,6 +9,7 @@ namespace Lcobucci\JWT;
 
 use BadMethodCallException;
 use DateTime;
+use DateTimeInterface;
 use Generator;
 use Lcobucci\JWT\Claim\Validatable;
 use OutOfBoundsException;
@@ -221,11 +222,11 @@ class Token
     /**
      * Determine if the token is expired.
      *
-     * @param DateTime $now Defaults to the current time.
+     * @param DateTimeInterface $now Defaults to the current time.
      *
      * @return bool
      */
-    public function isExpired(DateTime $now = null)
+    public function isExpired(DateTimeInterface $now = null)
     {
         $exp = $this->getClaim('exp', false);
 


### PR DESCRIPTION
I had an issue to use DateTimeImmutable in the library.
Also saw the 4.0 version has this feature, but since its not released I propose to make this happen in the current 3.x branch!

Let me know if it works!