### PR TITLE
Compare integers instead of objects

### DIFF
--- a/src/Token.php
+++ b/src/Token.php
@@ -232,10 +232,7 @@ class Token
 
         $now = $now ?: new DateTime();
 
-        $expiresAt = new DateTime();
-        $expiresAt->setTimestamp($exp);
-
-        return $now > $expiresAt;
+        return $now->getTimestamp() > $exp;
     }
 
     /**

--- a/src/Token.php
+++ b/src/Token.php
@@ -224,15 +224,13 @@ class Token
      */
     public function isExpired(DateTimeInterface $now = null)
     {
-        $exp = $this->getClaim('exp', false);
-
-        if ($exp === false) {
+        if (!$this->hasClaim('exp')) {
             return false;
         }
 
         $now = $now ?: new DateTime();
 
-        return $now->getTimestamp() > $exp;
+        return $now->getTimestamp() > $this->getClaim('exp');
     }
 
     /**


### PR DESCRIPTION
Since PHP 7.1 RC4 the Datetime object handles microtime properly but that breaks the logic we're using here (since the microtime of `$now` may be different than the one in `$exp`).