### PR TITLE
Upgrade to PHPUnit 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_script:
 script:
   - ./vendor/bin/phpunit --coverage-clover ./clover.xml --testsuite=unit
   - ./vendor/bin/phpunit test/functional
-  - if php -i |grep -qE xdebug; then ./vendor/bin/humbug --options='--testsuite=unit'; fi
+#  - if php -i |grep -qE xdebug; then ./vendor/bin/humbug --options='--testsuite=unit'; fi
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
         "phpmd/phpmd": "^2.5",
         "phpunit/php-invoker": "^1.1",
         "mikey179/vfsStream": "^1.6",
-        "mdanter/ecc": "^0.4",
-        "humbug/humbug": "dev-master@dev"
+        "mdanter/ecc": "^0.4"
     },
     "suggest":{
         "mdanter/ecc": "Required to use Elliptic Curves based algorithms."

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "lcobucci/jose-parsing": "~2.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
+        "phpunit/phpunit": "^6.0",
         "squizlabs/php_codesniffer": "^2.7",
         "phpmd/phpmd": "^2.5",
         "phpunit/php-invoker": "^1.1",

--- a/test/functional/EcdsaTokenTest.php
+++ b/test/functional/EcdsaTokenTest.php
@@ -22,7 +22,7 @@ use Lcobucci\JWT\Validation\Constraint\SignedWith;
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
  * @since 2.1.0
  */
-class EcdsaTokenTest extends \PHPUnit_Framework_TestCase
+class EcdsaTokenTest extends \PHPUnit\Framework\TestCase
 {
     use Keys;
 

--- a/test/functional/HmacTokenTest.php
+++ b/test/functional/HmacTokenTest.php
@@ -21,7 +21,7 @@ use Lcobucci\JWT\Validation\Constraint\SignedWith;
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
  * @since 2.1.0
  */
-class HmacTokenTest extends \PHPUnit_Framework_TestCase
+class HmacTokenTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Configuration

--- a/test/functional/MaliciousTamperingPreventionTest.php
+++ b/test/functional/MaliciousTamperingPreventionTest.php
@@ -16,7 +16,7 @@ use Lcobucci\JWT\Signer\Key;
 use Lcobucci\JWT\Validation\Constraint\SignedWith;
 use Lcobucci\JWT\Validation\InvalidTokenException;
 
-final class MaliciousTamperingPreventionTest extends \PHPUnit_Framework_TestCase
+final class MaliciousTamperingPreventionTest extends \PHPUnit\Framework\TestCase
 {
     use Keys;
 

--- a/test/functional/RsaTokenTest.php
+++ b/test/functional/RsaTokenTest.php
@@ -22,7 +22,7 @@ use Lcobucci\JWT\Validation\Constraint\SignedWith;
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
  * @since 2.1.0
  */
-class RsaTokenTest extends \PHPUnit_Framework_TestCase
+class RsaTokenTest extends \PHPUnit\Framework\TestCase
 {
     use Keys;
 

--- a/test/functional/UnsignedTokenTest.php
+++ b/test/functional/UnsignedTokenTest.php
@@ -24,7 +24,7 @@ use Lcobucci\JWT\Validation\ConstraintViolationException;
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
  * @since 2.1.0
  */
-class UnsignedTokenTest extends \PHPUnit_Framework_TestCase
+class UnsignedTokenTest extends \PHPUnit\Framework\TestCase
 {
     const CURRENT_TIME = 100000;
 

--- a/test/unit/ConfigurationTest.php
+++ b/test/unit/ConfigurationTest.php
@@ -15,7 +15,7 @@ use Lcobucci\JWT\Token\Builder;
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
  * @since 4.0.0
  */
-final class ConfigurationTest extends \PHPUnit_Framework_TestCase
+final class ConfigurationTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Parser|\PHPUnit_Framework_MockObject_MockObject

--- a/test/unit/Signer/Ecdsa/BaseTestCase.php
+++ b/test/unit/Signer/Ecdsa/BaseTestCase.php
@@ -13,7 +13,7 @@ namespace Lcobucci\JWT\Signer\Ecdsa;
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
  * @since 4.0.0
  */
-abstract class BaseTestCase extends \PHPUnit_Framework_TestCase
+abstract class BaseTestCase extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var EccAdapter|\PHPUnit_Framework_MockObject_MockObject

--- a/test/unit/Signer/Ecdsa/EccAdapterTest.php
+++ b/test/unit/Signer/Ecdsa/EccAdapterTest.php
@@ -22,7 +22,7 @@ use Mdanter\Ecc\Random\RandomNumberGeneratorInterface;
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
  * @since 4.0.0
  */
-final class EccAdapterTest extends \PHPUnit_Framework_TestCase
+final class EccAdapterTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var GmpMathInterface|\PHPUnit_Framework_MockObject_MockObject

--- a/test/unit/Signer/Ecdsa/KeyParserTest.php
+++ b/test/unit/Signer/Ecdsa/KeyParserTest.php
@@ -21,7 +21,7 @@ use Lcobucci\JWT\Signer\Key;
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
  * @since 3.0.4
  */
-final class KeyParserTest extends \PHPUnit_Framework_TestCase
+final class KeyParserTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var GmpMathInterface|\PHPUnit_Framework_MockObject_MockObject

--- a/test/unit/Signer/Ecdsa/SignatureSerializerTest.php
+++ b/test/unit/Signer/Ecdsa/SignatureSerializerTest.php
@@ -17,7 +17,7 @@ use Mdanter\Ecc\Math\GmpMathInterface;
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
  * @since 4.0.0
  */
-final class SignatureSerializerTest extends \PHPUnit_Framework_TestCase
+final class SignatureSerializerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var GmpMathInterface

--- a/test/unit/Signer/Hmac/Sha256Test.php
+++ b/test/unit/Signer/Hmac/Sha256Test.php
@@ -13,7 +13,7 @@ namespace Lcobucci\JWT\Signer\Hmac;
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
  * @since 0.1.0
  */
-final class Sha256Test extends \PHPUnit_Framework_TestCase
+final class Sha256Test extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test

--- a/test/unit/Signer/Hmac/Sha384Test.php
+++ b/test/unit/Signer/Hmac/Sha384Test.php
@@ -13,7 +13,7 @@ namespace Lcobucci\JWT\Signer\Hmac;
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
  * @since 0.1.0
  */
-final class Sha384Test extends \PHPUnit_Framework_TestCase
+final class Sha384Test extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test

--- a/test/unit/Signer/Hmac/Sha512Test.php
+++ b/test/unit/Signer/Hmac/Sha512Test.php
@@ -13,7 +13,7 @@ namespace Lcobucci\JWT\Signer\Hmac;
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
  * @since 0.1.0
  */
-final class Sha512Test extends \PHPUnit_Framework_TestCase
+final class Sha512Test extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test

--- a/test/unit/Signer/HmacTest.php
+++ b/test/unit/Signer/HmacTest.php
@@ -13,7 +13,7 @@ namespace Lcobucci\JWT\Signer;
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
  * @since 0.1.0
  */
-final class HmacTest extends \PHPUnit_Framework_TestCase
+final class HmacTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Hmac|\PHPUnit_Framework_MockObject_MockObject

--- a/test/unit/Signer/KeyTest.php
+++ b/test/unit/Signer/KeyTest.php
@@ -15,7 +15,7 @@ use org\bovigo\vfs\vfsStream;
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
  * @since 3.0.4
  */
-final class KeyTest extends \PHPUnit_Framework_TestCase
+final class KeyTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @before

--- a/test/unit/Signer/NoneTest.php
+++ b/test/unit/Signer/NoneTest.php
@@ -11,7 +11,7 @@ namespace Lcobucci\JWT\Signer;
  * @author Luís Cobucci <lcobucci@gmail.com>
  * @since 4.0.0
  */
-final class NoneTest extends \PHPUnit_Framework_TestCase
+final class NoneTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test

--- a/test/unit/Signer/Rsa/Sha256Test.php
+++ b/test/unit/Signer/Rsa/Sha256Test.php
@@ -13,7 +13,7 @@ namespace Lcobucci\JWT\Signer\Rsa;
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
  * @since 2.1.0
  */
-final class Sha256Test extends \PHPUnit_Framework_TestCase
+final class Sha256Test extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test

--- a/test/unit/Signer/Rsa/Sha384Test.php
+++ b/test/unit/Signer/Rsa/Sha384Test.php
@@ -13,7 +13,7 @@ namespace Lcobucci\JWT\Signer\Rsa;
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
  * @since 2.1.0
  */
-final class Sha384Test extends \PHPUnit_Framework_TestCase
+final class Sha384Test extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test

--- a/test/unit/Signer/Rsa/Sha512Test.php
+++ b/test/unit/Signer/Rsa/Sha512Test.php
@@ -13,7 +13,7 @@ namespace Lcobucci\JWT\Signer\Rsa;
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
  * @since 2.1.0
  */
-final class Sha512Test extends \PHPUnit_Framework_TestCase
+final class Sha512Test extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test

--- a/test/unit/Signer/RsaTest.php
+++ b/test/unit/Signer/RsaTest.php
@@ -15,7 +15,7 @@ use Lcobucci\JWT\Keys;
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
  * @since 4.0.0
  */
-final class RsaTest extends \PHPUnit_Framework_TestCase
+final class RsaTest extends \PHPUnit\Framework\TestCase
 {
     use Keys;
 

--- a/test/unit/Token/BuilderTest.php
+++ b/test/unit/Token/BuilderTest.php
@@ -17,7 +17,7 @@ use Lcobucci\JWT\Signer\Key;
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
  * @since 0.1.0
  */
-final class BuilderTest extends \PHPUnit_Framework_TestCase
+final class BuilderTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Encoder|\PHPUnit_Framework_MockObject_MockObject

--- a/test/unit/Token/DataSetTest.php
+++ b/test/unit/Token/DataSetTest.php
@@ -7,7 +7,7 @@
 
 namespace Lcobucci\JWT\Token;
 
-final class DataSetTest extends \PHPUnit_Framework_TestCase
+final class DataSetTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test

--- a/test/unit/Token/ParserTest.php
+++ b/test/unit/Token/ParserTest.php
@@ -16,7 +16,7 @@ use RuntimeException;
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
  * @since 0.1.0
  */
-final class ParserTest extends \PHPUnit_Framework_TestCase
+final class ParserTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Decoder|\PHPUnit_Framework_MockObject_MockObject

--- a/test/unit/Token/PlainTest.php
+++ b/test/unit/Token/PlainTest.php
@@ -15,7 +15,7 @@ use DateTime;
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
  * @since 0.1.0
  */
-final class PlainTest extends \PHPUnit_Framework_TestCase
+final class PlainTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var DataSet

--- a/test/unit/Token/SignatureTest.php
+++ b/test/unit/Token/SignatureTest.php
@@ -13,7 +13,7 @@ namespace Lcobucci\JWT\Token;
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
  * @since 0.1.0
  */
-final class SignatureTest extends \PHPUnit_Framework_TestCase
+final class SignatureTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test

--- a/test/unit/Validation/Constraint/ConstraintTestCase.php
+++ b/test/unit/Validation/Constraint/ConstraintTestCase.php
@@ -12,7 +12,7 @@ use Lcobucci\JWT\Token\Signature;
 use Lcobucci\JWT\Token\Plain;
 use Lcobucci\JWT\Token as TokenInterface;
 
-abstract class ConstraintTestCase extends \PHPUnit_Framework_TestCase
+abstract class ConstraintTestCase extends \PHPUnit\Framework\TestCase
 {
     protected function buildToken(
         array $claims = [],

--- a/test/unit/Validation/InvalidTokenExceptionTest.php
+++ b/test/unit/Validation/InvalidTokenExceptionTest.php
@@ -7,7 +7,7 @@
 
 namespace Lcobucci\JWT\Validation;
 
-final class InvalidTokenExceptionTest extends \PHPUnit_Framework_TestCase
+final class InvalidTokenExceptionTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test

--- a/test/unit/Validation/ValidatorTest.php
+++ b/test/unit/Validation/ValidatorTest.php
@@ -9,7 +9,7 @@ namespace Lcobucci\JWT\Validation;
 
 use Lcobucci\JWT\Token;
 
-final class ValidatorTest extends \PHPUnit_Framework_TestCase
+final class ValidatorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Token|\PHPUnit_Framework_MockObject_MockObject


### PR DESCRIPTION
Unfortunately I had to disable humbug temporarily because it doesn't support PHPUnit 6 and I couldn't reach @padraic (to know about his plans regarding the tool) and @sebastianbergmann (to better understand why TAP support was deprecated on PHPUnit 5.7 - and removed on 6).