### PR TITLE
Simplify registered claims usage

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Lcobucci\JWT;
 
-use BadMethodCallException;
 use Lcobucci\JWT\Signer\Key;
 use Lcobucci\JWT\Token\Plain;
 
@@ -56,15 +55,13 @@ interface Builder
 
     /**
      * Configures a header item
-     *
-     * @throws BadMethodCallException When data has been already signed
      */
     public function withHeader(string $name, $value): Builder;
 
     /**
      * Configures a claim item
      *
-     * @throws BadMethodCallException When data has been already signed
+     * @throws \InvalidArgumentException When trying to set a registered claim
      */
     public function withClaim(string $name, $value): Builder;
 

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -22,37 +22,37 @@ interface Builder
     /**
      * Appends a new audience
      */
-    public function permittedFor(string $audience, bool $addHeader = false): Builder;
+    public function permittedFor(string $audience): Builder;
 
     /**
      * Configures the expiration time
      */
-    public function expiresAt(int $expiration, bool $addHeader = false): Builder;
+    public function expiresAt(int $expiration): Builder;
 
     /**
      * Configures the token id
      */
-    public function identifiedBy(string $id, bool $addHeader = false): Builder;
+    public function identifiedBy(string $id): Builder;
 
     /**
      * Configures the time that the token was issued
      */
-    public function issuedAt(int $issuedAt, bool $addHeader = false): Builder;
+    public function issuedAt(int $issuedAt): Builder;
 
     /**
      * Configures the issuer
      */
-    public function issuedBy(string $issuer, bool $addHeader = false): Builder;
+    public function issuedBy(string $issuer): Builder;
 
     /**
      * Configures the time before which the token cannot be accepted
      */
-    public function canOnlyBeUsedAfter(int $notBefore, bool $addHeader = false): Builder;
+    public function canOnlyBeUsedAfter(int $notBefore): Builder;
 
     /**
      * Configures the subject
      */
-    public function relatedTo(string $subject, bool $addHeader = false): Builder;
+    public function relatedTo(string $subject): Builder;
 
     /**
      * Configures a header item

--- a/src/Token/Builder.php
+++ b/src/Token/Builder.php
@@ -55,7 +55,7 @@ final class Builder implements BuilderInterface
     /**
      * {@inheritdoc}
      */
-    public function permittedFor(string $audience, bool $addHeader = false): BuilderInterface
+    public function permittedFor(string $audience): BuilderInterface
     {
         $audiences = $this->claims[RegisteredClaims::AUDIENCE] ?? [];
 
@@ -63,69 +63,55 @@ final class Builder implements BuilderInterface
             $audiences[] = $audience;
         }
 
-        return $this->setRegisteredClaim(RegisteredClaims::AUDIENCE, $audiences, $addHeader);
+        return $this->withClaim(RegisteredClaims::AUDIENCE, $audiences);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function expiresAt(int $expiration, bool $addHeader = false): BuilderInterface
+    public function expiresAt(int $expiration): BuilderInterface
     {
-        return $this->setRegisteredClaim(RegisteredClaims::EXPIRATION_TIME, $expiration, $addHeader);
+        return $this->withClaim(RegisteredClaims::EXPIRATION_TIME, $expiration);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function identifiedBy(string $id, bool $addHeader = false): BuilderInterface
+    public function identifiedBy(string $id): BuilderInterface
     {
-        return $this->setRegisteredClaim(RegisteredClaims::ID, $id, $addHeader);
+        return $this->withClaim(RegisteredClaims::ID, $id);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function issuedAt(int $issuedAt, bool $addHeader = false): BuilderInterface
+    public function issuedAt(int $issuedAt): BuilderInterface
     {
-        return $this->setRegisteredClaim(RegisteredClaims::ISSUED_AT, (int) $issuedAt, $addHeader);
+        return $this->withClaim(RegisteredClaims::ISSUED_AT, $issuedAt);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function issuedBy(string $issuer, bool $addHeader = false): BuilderInterface
+    public function issuedBy(string $issuer): BuilderInterface
     {
-        return $this->setRegisteredClaim(RegisteredClaims::ISSUER, $issuer, $addHeader);
+        return $this->withClaim(RegisteredClaims::ISSUER, $issuer);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function canOnlyBeUsedAfter(int $notBefore, bool $addHeader = false): BuilderInterface
+    public function canOnlyBeUsedAfter(int $notBefore): BuilderInterface
     {
-        return $this->setRegisteredClaim(RegisteredClaims::NOT_BEFORE, $notBefore, $addHeader);
+        return $this->withClaim(RegisteredClaims::NOT_BEFORE, $notBefore);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function relatedTo(string $subject, bool $addHeader = false): BuilderInterface
+    public function relatedTo(string $subject): BuilderInterface
     {
-        return $this->setRegisteredClaim(RegisteredClaims::SUBJECT, $subject, $addHeader);
-    }
-
-    /**
-     * Configures a registered claim
-     */
-    private function setRegisteredClaim(string $name, $value, bool $addHeader): BuilderInterface
-    {
-        $this->withClaim($name, $value);
-
-        if ($addHeader) {
-            $this->headers[$name] = $this->claims[$name];
-        }
-
-        return $this;
+        return $this->withClaim(RegisteredClaims::SUBJECT, $subject);
     }
 
     /**

--- a/src/Token/Builder.php
+++ b/src/Token/Builder.php
@@ -63,7 +63,7 @@ final class Builder implements BuilderInterface
             $audiences[] = $audience;
         }
 
-        return $this->withClaim(RegisteredClaims::AUDIENCE, $audiences);
+        return $this->setClaim(RegisteredClaims::AUDIENCE, $audiences);
     }
 
     /**
@@ -71,7 +71,7 @@ final class Builder implements BuilderInterface
      */
     public function expiresAt(int $expiration): BuilderInterface
     {
-        return $this->withClaim(RegisteredClaims::EXPIRATION_TIME, $expiration);
+        return $this->setClaim(RegisteredClaims::EXPIRATION_TIME, $expiration);
     }
 
     /**
@@ -79,7 +79,7 @@ final class Builder implements BuilderInterface
      */
     public function identifiedBy(string $id): BuilderInterface
     {
-        return $this->withClaim(RegisteredClaims::ID, $id);
+        return $this->setClaim(RegisteredClaims::ID, $id);
     }
 
     /**
@@ -87,7 +87,7 @@ final class Builder implements BuilderInterface
      */
     public function issuedAt(int $issuedAt): BuilderInterface
     {
-        return $this->withClaim(RegisteredClaims::ISSUED_AT, $issuedAt);
+        return $this->setClaim(RegisteredClaims::ISSUED_AT, $issuedAt);
     }
 
     /**
@@ -95,7 +95,7 @@ final class Builder implements BuilderInterface
      */
     public function issuedBy(string $issuer): BuilderInterface
     {
-        return $this->withClaim(RegisteredClaims::ISSUER, $issuer);
+        return $this->setClaim(RegisteredClaims::ISSUER, $issuer);
     }
 
     /**
@@ -103,7 +103,7 @@ final class Builder implements BuilderInterface
      */
     public function canOnlyBeUsedAfter(int $notBefore): BuilderInterface
     {
-        return $this->withClaim(RegisteredClaims::NOT_BEFORE, $notBefore);
+        return $this->setClaim(RegisteredClaims::NOT_BEFORE, $notBefore);
     }
 
     /**
@@ -111,7 +111,7 @@ final class Builder implements BuilderInterface
      */
     public function relatedTo(string $subject): BuilderInterface
     {
-        return $this->withClaim(RegisteredClaims::SUBJECT, $subject);
+        return $this->setClaim(RegisteredClaims::SUBJECT, $subject);
     }
 
     /**
@@ -128,6 +128,15 @@ final class Builder implements BuilderInterface
      * {@inheritdoc}
      */
     public function withClaim(string $name, $value): BuilderInterface
+    {
+        if (in_array($name, RegisteredClaims::ALL, true)) {
+            throw new \InvalidArgumentException('You should use the correct methods to set registered claims');
+        }
+
+        return $this->setClaim($name, $value);
+    }
+
+    private function setClaim(string $name, $value): BuilderInterface
     {
         $this->claims[$name] = $value;
 

--- a/src/Token/RegisteredClaims.php
+++ b/src/Token/RegisteredClaims.php
@@ -17,6 +17,16 @@ namespace Lcobucci\JWT\Token;
  */
 interface RegisteredClaims
 {
+    const ALL = [
+        self::AUDIENCE,
+        self::EXPIRATION_TIME,
+        self::ID,
+        self::ISSUED_AT,
+        self::ISSUER,
+        self::NOT_BEFORE,
+        self::SUBJECT
+    ];
+
     /**
      * Identifies the recipients that the JWT is intended for
      *

--- a/test/unit/Token/BuilderTest.php
+++ b/test/unit/Token/BuilderTest.php
@@ -67,7 +67,7 @@ final class BuilderTest extends \PHPUnit\Framework\TestCase
      * @uses \Lcobucci\JWT\Token\Builder::__construct
      *
      * @covers \Lcobucci\JWT\Token\Builder::permittedFor
-     * @covers \Lcobucci\JWT\Token\Builder::withClaim
+     * @covers \Lcobucci\JWT\Token\Builder::setClaim
      */
     public function permittedForMustAppendToTheAudClaim(): void
     {
@@ -85,7 +85,7 @@ final class BuilderTest extends \PHPUnit\Framework\TestCase
      * @uses \Lcobucci\JWT\Token\Builder::__construct
      *
      * @covers \Lcobucci\JWT\Token\Builder::permittedFor
-     * @covers \Lcobucci\JWT\Token\Builder::withClaim
+     * @covers \Lcobucci\JWT\Token\Builder::setClaim
      */
     public function permittedForShouldPreventDuplicatedEntries(): void
     {
@@ -103,7 +103,7 @@ final class BuilderTest extends \PHPUnit\Framework\TestCase
      * @uses \Lcobucci\JWT\Token\Builder::__construct
      *
      * @covers \Lcobucci\JWT\Token\Builder::permittedFor
-     * @covers \Lcobucci\JWT\Token\Builder::withClaim
+     * @covers \Lcobucci\JWT\Token\Builder::setClaim
      */
     public function permittedForMustKeepAFluentInterface(): void
     {
@@ -118,7 +118,7 @@ final class BuilderTest extends \PHPUnit\Framework\TestCase
      * @uses \Lcobucci\JWT\Token\Builder::__construct
      *
      * @covers \Lcobucci\JWT\Token\Builder::expiresAt
-     * @covers \Lcobucci\JWT\Token\Builder::withClaim
+     * @covers \Lcobucci\JWT\Token\Builder::setClaim
      */
     public function expiresAtMustChangeTheExpClaim(): void
     {
@@ -135,7 +135,7 @@ final class BuilderTest extends \PHPUnit\Framework\TestCase
      * @uses \Lcobucci\JWT\Token\Builder::__construct
      *
      * @covers \Lcobucci\JWT\Token\Builder::expiresAt
-     * @covers \Lcobucci\JWT\Token\Builder::withClaim
+     * @covers \Lcobucci\JWT\Token\Builder::setClaim
      */
     public function expiresAtMustKeepAFluentInterface(): void
     {
@@ -150,7 +150,7 @@ final class BuilderTest extends \PHPUnit\Framework\TestCase
      * @uses \Lcobucci\JWT\Token\Builder::__construct
      *
      * @covers \Lcobucci\JWT\Token\Builder::identifiedBy
-     * @covers \Lcobucci\JWT\Token\Builder::withClaim
+     * @covers \Lcobucci\JWT\Token\Builder::setClaim
      */
     public function withIdMustChangeTheJtiClaim(): void
     {
@@ -167,7 +167,7 @@ final class BuilderTest extends \PHPUnit\Framework\TestCase
      * @uses \Lcobucci\JWT\Token\Builder::__construct
      *
      * @covers \Lcobucci\JWT\Token\Builder::identifiedBy
-     * @covers \Lcobucci\JWT\Token\Builder::withClaim
+     * @covers \Lcobucci\JWT\Token\Builder::setClaim
      */
     public function withIdMustKeepAFluentInterface(): void
     {
@@ -182,7 +182,7 @@ final class BuilderTest extends \PHPUnit\Framework\TestCase
      * @uses \Lcobucci\JWT\Token\Builder::__construct
      *
      * @covers \Lcobucci\JWT\Token\Builder::issuedAt
-     * @covers \Lcobucci\JWT\Token\Builder::withClaim
+     * @covers \Lcobucci\JWT\Token\Builder::setClaim
      */
     public function issuedAtMustChangeTheIatClaim(): void
     {
@@ -199,7 +199,7 @@ final class BuilderTest extends \PHPUnit\Framework\TestCase
      * @uses \Lcobucci\JWT\Token\Builder::__construct
      *
      * @covers \Lcobucci\JWT\Token\Builder::issuedAt
-     * @covers \Lcobucci\JWT\Token\Builder::withClaim
+     * @covers \Lcobucci\JWT\Token\Builder::setClaim
      */
     public function issuedAtMustKeepAFluentInterface(): void
     {
@@ -214,7 +214,7 @@ final class BuilderTest extends \PHPUnit\Framework\TestCase
      * @uses \Lcobucci\JWT\Token\Builder::__construct
      *
      * @covers \Lcobucci\JWT\Token\Builder::issuedBy
-     * @covers \Lcobucci\JWT\Token\Builder::withClaim
+     * @covers \Lcobucci\JWT\Token\Builder::setClaim
      */
     public function issuedByMustChangeTheIssClaim(): void
     {
@@ -231,7 +231,7 @@ final class BuilderTest extends \PHPUnit\Framework\TestCase
      * @uses \Lcobucci\JWT\Token\Builder::__construct
      *
      * @covers \Lcobucci\JWT\Token\Builder::issuedBy
-     * @covers \Lcobucci\JWT\Token\Builder::withClaim
+     * @covers \Lcobucci\JWT\Token\Builder::setClaim
      */
     public function issuedByMustKeepAFluentInterface(): void
     {
@@ -246,7 +246,7 @@ final class BuilderTest extends \PHPUnit\Framework\TestCase
      * @uses \Lcobucci\JWT\Token\Builder::__construct
      *
      * @covers \Lcobucci\JWT\Token\Builder::canOnlyBeUsedAfter
-     * @covers \Lcobucci\JWT\Token\Builder::withClaim
+     * @covers \Lcobucci\JWT\Token\Builder::setClaim
      */
     public function canOnlyBeUsedAfterMustChangeTheNbfClaim(): void
     {
@@ -263,7 +263,7 @@ final class BuilderTest extends \PHPUnit\Framework\TestCase
      * @uses \Lcobucci\JWT\Token\Builder::__construct
      *
      * @covers \Lcobucci\JWT\Token\Builder::canOnlyBeUsedAfter
-     * @covers \Lcobucci\JWT\Token\Builder::withClaim
+     * @covers \Lcobucci\JWT\Token\Builder::setClaim
      */
     public function canOnlyBeUsedAfterMustKeepAFluentInterface(): void
     {
@@ -278,7 +278,7 @@ final class BuilderTest extends \PHPUnit\Framework\TestCase
      * @uses \Lcobucci\JWT\Token\Builder::__construct
      *
      * @covers \Lcobucci\JWT\Token\Builder::relatedTo
-     * @covers \Lcobucci\JWT\Token\Builder::withClaim
+     * @covers \Lcobucci\JWT\Token\Builder::setClaim
      */
     public function relatedToMustChangeTheSubClaim(): void
     {
@@ -295,7 +295,7 @@ final class BuilderTest extends \PHPUnit\Framework\TestCase
      * @uses \Lcobucci\JWT\Token\Builder::__construct
      *
      * @covers \Lcobucci\JWT\Token\Builder::relatedTo
-     * @covers \Lcobucci\JWT\Token\Builder::withClaim
+     * @covers \Lcobucci\JWT\Token\Builder::setClaim
      */
     public function relatedToMustKeepAFluentInterface(): void
     {
@@ -307,9 +307,25 @@ final class BuilderTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      *
+     * @expectedException \InvalidArgumentException
+     *
      * @uses \Lcobucci\JWT\Token\Builder::__construct
      *
      * @covers \Lcobucci\JWT\Token\Builder::withClaim
+     */
+    public function withClaimShouldRaiseExceptionWhenTryingToConfigureARegisteredClaim(): void
+    {
+        $builder = $this->createBuilder();
+        $builder->withClaim(RegisteredClaims::ISSUER, 'me');
+    }
+
+    /**
+     * @test
+     *
+     * @uses \Lcobucci\JWT\Token\Builder::__construct
+     *
+     * @covers \Lcobucci\JWT\Token\Builder::withClaim
+     * @covers \Lcobucci\JWT\Token\Builder::setClaim
      */
     public function withClaimMustConfigureTheGivenClaim(): void
     {
@@ -325,6 +341,7 @@ final class BuilderTest extends \PHPUnit\Framework\TestCase
      * @uses \Lcobucci\JWT\Token\Builder::__construct
      *
      * @covers \Lcobucci\JWT\Token\Builder::withClaim
+     * @covers \Lcobucci\JWT\Token\Builder::setClaim
      */
     public function withClaimMustKeepAFluentInterface(): void
     {
@@ -339,6 +356,7 @@ final class BuilderTest extends \PHPUnit\Framework\TestCase
      * @uses \Lcobucci\JWT\Token\Builder::__construct
      *
      * @covers \Lcobucci\JWT\Token\Builder::withHeader
+     * @covers \Lcobucci\JWT\Token\Builder::setClaim
      */
     public function withHeaderMustConfigureTheGivenClaim(): void
     {
@@ -371,6 +389,7 @@ final class BuilderTest extends \PHPUnit\Framework\TestCase
      *
      * @uses \Lcobucci\JWT\Token\Builder::__construct
      * @uses \Lcobucci\JWT\Token\Builder::withClaim
+     * @uses \Lcobucci\JWT\Token\Builder::setClaim
      * @uses \Lcobucci\JWT\Signer\Key
      * @uses \Lcobucci\JWT\Token\Plain
      * @uses \Lcobucci\JWT\Token\Signature

--- a/test/unit/Token/BuilderTest.php
+++ b/test/unit/Token/BuilderTest.php
@@ -65,10 +65,9 @@ final class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses \Lcobucci\JWT\Token\Builder::__construct
-     * @uses \Lcobucci\JWT\Token\Builder::withClaim
      *
      * @covers \Lcobucci\JWT\Token\Builder::permittedFor
-     * @covers \Lcobucci\JWT\Token\Builder::setRegisteredClaim
+     * @covers \Lcobucci\JWT\Token\Builder::withClaim
      */
     public function permittedForMustAppendToTheAudClaim(): void
     {
@@ -84,10 +83,9 @@ final class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses \Lcobucci\JWT\Token\Builder::__construct
-     * @uses \Lcobucci\JWT\Token\Builder::withClaim
      *
      * @covers \Lcobucci\JWT\Token\Builder::permittedFor
-     * @covers \Lcobucci\JWT\Token\Builder::setRegisteredClaim
+     * @covers \Lcobucci\JWT\Token\Builder::withClaim
      */
     public function permittedForShouldPreventDuplicatedEntries(): void
     {
@@ -103,33 +101,9 @@ final class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses \Lcobucci\JWT\Token\Builder::__construct
-     * @uses \Lcobucci\JWT\Token\Builder::withClaim
      *
      * @covers \Lcobucci\JWT\Token\Builder::permittedFor
-     * @covers \Lcobucci\JWT\Token\Builder::setRegisteredClaim
-     */
-    public function permittedForCanReplicateItemOnHeader(): void
-    {
-        $builder = $this->createBuilder();
-        $builder->permittedFor('test', true);
-
-        self::assertAttributeEquals([RegisteredClaims::AUDIENCE => ['test']], 'claims', $builder);
-
-        self::assertAttributeEquals(
-            ['alg' => 'none', 'typ' => 'JWT', RegisteredClaims::AUDIENCE => ['test']],
-            'headers',
-            $builder
-        );
-    }
-
-    /**
-     * @test
-     *
-     * @uses \Lcobucci\JWT\Token\Builder::__construct
-     * @uses \Lcobucci\JWT\Token\Builder::withClaim
-     *
-     * @covers \Lcobucci\JWT\Token\Builder::permittedFor
-     * @covers \Lcobucci\JWT\Token\Builder::setRegisteredClaim
+     * @covers \Lcobucci\JWT\Token\Builder::withClaim
      */
     public function permittedForMustKeepAFluentInterface(): void
     {
@@ -142,10 +116,9 @@ final class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses \Lcobucci\JWT\Token\Builder::__construct
-     * @uses \Lcobucci\JWT\Token\Builder::withClaim
      *
      * @covers \Lcobucci\JWT\Token\Builder::expiresAt
-     * @covers \Lcobucci\JWT\Token\Builder::setRegisteredClaim
+     * @covers \Lcobucci\JWT\Token\Builder::withClaim
      */
     public function expiresAtMustChangeTheExpClaim(): void
     {
@@ -160,33 +133,9 @@ final class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses \Lcobucci\JWT\Token\Builder::__construct
-     * @uses \Lcobucci\JWT\Token\Builder::withClaim
      *
      * @covers \Lcobucci\JWT\Token\Builder::expiresAt
-     * @covers \Lcobucci\JWT\Token\Builder::setRegisteredClaim
-     */
-    public function expiresAtCanReplicateItemOnHeader(): void
-    {
-        $builder = $this->createBuilder();
-        $builder->expiresAt(2, true);
-
-        self::assertAttributeEquals([RegisteredClaims::EXPIRATION_TIME => 2], 'claims', $builder);
-
-        self::assertAttributeEquals(
-            ['alg' => 'none', 'typ' => 'JWT', RegisteredClaims::EXPIRATION_TIME => 2],
-            'headers',
-            $builder
-        );
-    }
-
-    /**
-     * @test
-     *
-     * @uses \Lcobucci\JWT\Token\Builder::__construct
-     * @uses \Lcobucci\JWT\Token\Builder::withClaim
-     *
-     * @covers \Lcobucci\JWT\Token\Builder::expiresAt
-     * @covers \Lcobucci\JWT\Token\Builder::setRegisteredClaim
+     * @covers \Lcobucci\JWT\Token\Builder::withClaim
      */
     public function expiresAtMustKeepAFluentInterface(): void
     {
@@ -199,10 +148,9 @@ final class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses \Lcobucci\JWT\Token\Builder::__construct
-     * @uses \Lcobucci\JWT\Token\Builder::withClaim
      *
      * @covers \Lcobucci\JWT\Token\Builder::identifiedBy
-     * @covers \Lcobucci\JWT\Token\Builder::setRegisteredClaim
+     * @covers \Lcobucci\JWT\Token\Builder::withClaim
      */
     public function withIdMustChangeTheJtiClaim(): void
     {
@@ -217,33 +165,9 @@ final class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses \Lcobucci\JWT\Token\Builder::__construct
-     * @uses \Lcobucci\JWT\Token\Builder::withClaim
      *
      * @covers \Lcobucci\JWT\Token\Builder::identifiedBy
-     * @covers \Lcobucci\JWT\Token\Builder::setRegisteredClaim
-     */
-    public function withIdCanReplicateItemOnHeader(): void
-    {
-        $builder = $this->createBuilder();
-        $builder->identifiedBy('2', true);
-
-        self::assertAttributeEquals([RegisteredClaims::ID => '2'], 'claims', $builder);
-
-        self::assertAttributeEquals(
-            ['alg' => 'none', 'typ' => 'JWT', RegisteredClaims::ID => '2'],
-            'headers',
-            $builder
-        );
-    }
-
-    /**
-     * @test
-     *
-     * @uses \Lcobucci\JWT\Token\Builder::__construct
-     * @uses \Lcobucci\JWT\Token\Builder::withClaim
-     *
-     * @covers \Lcobucci\JWT\Token\Builder::identifiedBy
-     * @covers \Lcobucci\JWT\Token\Builder::setRegisteredClaim
+     * @covers \Lcobucci\JWT\Token\Builder::withClaim
      */
     public function withIdMustKeepAFluentInterface(): void
     {
@@ -256,10 +180,9 @@ final class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses \Lcobucci\JWT\Token\Builder::__construct
-     * @uses \Lcobucci\JWT\Token\Builder::withClaim
      *
      * @covers \Lcobucci\JWT\Token\Builder::issuedAt
-     * @covers \Lcobucci\JWT\Token\Builder::setRegisteredClaim
+     * @covers \Lcobucci\JWT\Token\Builder::withClaim
      */
     public function issuedAtMustChangeTheIatClaim(): void
     {
@@ -274,33 +197,9 @@ final class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses \Lcobucci\JWT\Token\Builder::__construct
-     * @uses \Lcobucci\JWT\Token\Builder::withClaim
      *
      * @covers \Lcobucci\JWT\Token\Builder::issuedAt
-     * @covers \Lcobucci\JWT\Token\Builder::setRegisteredClaim
-     */
-    public function issuedAtCanReplicateItemOnHeader(): void
-    {
-        $builder = $this->createBuilder();
-        $builder->issuedAt(2, true);
-
-        self::assertAttributeEquals([RegisteredClaims::ISSUED_AT => 2], 'claims', $builder);
-
-        self::assertAttributeEquals(
-            ['alg' => 'none', 'typ' => 'JWT', RegisteredClaims::ISSUED_AT => 2],
-            'headers',
-            $builder
-        );
-    }
-
-    /**
-     * @test
-     *
-     * @uses \Lcobucci\JWT\Token\Builder::__construct
-     * @uses \Lcobucci\JWT\Token\Builder::withClaim
-     *
-     * @covers \Lcobucci\JWT\Token\Builder::issuedAt
-     * @covers \Lcobucci\JWT\Token\Builder::setRegisteredClaim
+     * @covers \Lcobucci\JWT\Token\Builder::withClaim
      */
     public function issuedAtMustKeepAFluentInterface(): void
     {
@@ -313,10 +212,9 @@ final class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses \Lcobucci\JWT\Token\Builder::__construct
-     * @uses \Lcobucci\JWT\Token\Builder::withClaim
      *
      * @covers \Lcobucci\JWT\Token\Builder::issuedBy
-     * @covers \Lcobucci\JWT\Token\Builder::setRegisteredClaim
+     * @covers \Lcobucci\JWT\Token\Builder::withClaim
      */
     public function issuedByMustChangeTheIssClaim(): void
     {
@@ -331,33 +229,9 @@ final class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses \Lcobucci\JWT\Token\Builder::__construct
-     * @uses \Lcobucci\JWT\Token\Builder::withClaim
      *
      * @covers \Lcobucci\JWT\Token\Builder::issuedBy
-     * @covers \Lcobucci\JWT\Token\Builder::setRegisteredClaim
-     */
-    public function issuedByCanReplicateItemOnHeader(): void
-    {
-        $builder = $this->createBuilder();
-        $builder->issuedBy('2', true);
-
-        self::assertAttributeEquals([RegisteredClaims::ISSUER => '2'], 'claims', $builder);
-
-        self::assertAttributeEquals(
-            ['alg' => 'none', 'typ' => 'JWT', RegisteredClaims::ISSUER => '2'],
-            'headers',
-            $builder
-        );
-    }
-
-    /**
-     * @test
-     *
-     * @uses \Lcobucci\JWT\Token\Builder::__construct
-     * @uses \Lcobucci\JWT\Token\Builder::withClaim
-     *
-     * @covers \Lcobucci\JWT\Token\Builder::issuedBy
-     * @covers \Lcobucci\JWT\Token\Builder::setRegisteredClaim
+     * @covers \Lcobucci\JWT\Token\Builder::withClaim
      */
     public function issuedByMustKeepAFluentInterface(): void
     {
@@ -370,10 +244,9 @@ final class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses \Lcobucci\JWT\Token\Builder::__construct
-     * @uses \Lcobucci\JWT\Token\Builder::withClaim
      *
      * @covers \Lcobucci\JWT\Token\Builder::canOnlyBeUsedAfter
-     * @covers \Lcobucci\JWT\Token\Builder::setRegisteredClaim
+     * @covers \Lcobucci\JWT\Token\Builder::withClaim
      */
     public function canOnlyBeUsedAfterMustChangeTheNbfClaim(): void
     {
@@ -388,33 +261,9 @@ final class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses \Lcobucci\JWT\Token\Builder::__construct
-     * @uses \Lcobucci\JWT\Token\Builder::withClaim
      *
      * @covers \Lcobucci\JWT\Token\Builder::canOnlyBeUsedAfter
-     * @covers \Lcobucci\JWT\Token\Builder::setRegisteredClaim
-     */
-    public function canOnlyBeUsedAfterCanReplicateItemOnHeader(): void
-    {
-        $builder = $this->createBuilder();
-        $builder->canOnlyBeUsedAfter(2, true);
-
-        self::assertAttributeEquals([RegisteredClaims::NOT_BEFORE => 2], 'claims', $builder);
-
-        self::assertAttributeEquals(
-            ['alg' => 'none', 'typ' => 'JWT', RegisteredClaims::NOT_BEFORE => 2],
-            'headers',
-            $builder
-        );
-    }
-
-    /**
-     * @test
-     *
-     * @uses \Lcobucci\JWT\Token\Builder::__construct
-     * @uses \Lcobucci\JWT\Token\Builder::withClaim
-     *
-     * @covers \Lcobucci\JWT\Token\Builder::canOnlyBeUsedAfter
-     * @covers \Lcobucci\JWT\Token\Builder::setRegisteredClaim
+     * @covers \Lcobucci\JWT\Token\Builder::withClaim
      */
     public function canOnlyBeUsedAfterMustKeepAFluentInterface(): void
     {
@@ -427,10 +276,9 @@ final class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses \Lcobucci\JWT\Token\Builder::__construct
-     * @uses \Lcobucci\JWT\Token\Builder::withClaim
      *
      * @covers \Lcobucci\JWT\Token\Builder::relatedTo
-     * @covers \Lcobucci\JWT\Token\Builder::setRegisteredClaim
+     * @covers \Lcobucci\JWT\Token\Builder::withClaim
      */
     public function relatedToMustChangeTheSubClaim(): void
     {
@@ -445,33 +293,9 @@ final class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses \Lcobucci\JWT\Token\Builder::__construct
-     * @uses \Lcobucci\JWT\Token\Builder::withClaim
      *
      * @covers \Lcobucci\JWT\Token\Builder::relatedTo
-     * @covers \Lcobucci\JWT\Token\Builder::setRegisteredClaim
-     */
-    public function relatedToCanReplicateItemOnHeader(): void
-    {
-        $builder = $this->createBuilder();
-        $builder->relatedTo('2', true);
-
-        self::assertAttributeEquals([RegisteredClaims::SUBJECT => '2'], 'claims', $builder);
-
-        self::assertAttributeEquals(
-            ['alg' => 'none', 'typ' => 'JWT', RegisteredClaims::SUBJECT => '2'],
-            'headers',
-            $builder
-        );
-    }
-
-    /**
-     * @test
-     *
-     * @uses \Lcobucci\JWT\Token\Builder::__construct
-     * @uses \Lcobucci\JWT\Token\Builder::withClaim
-     *
-     * @covers \Lcobucci\JWT\Token\Builder::relatedTo
-     * @covers \Lcobucci\JWT\Token\Builder::setRegisteredClaim
+     * @covers \Lcobucci\JWT\Token\Builder::withClaim
      */
     public function relatedToMustKeepAFluentInterface(): void
     {


### PR DESCRIPTION
This basically removes the replication to headers feature (which is just needed for encryption) and makes sure nobody is able to set a registered claim using `Builder#withClaim()`.