### PR TITLE
Fix: Cache dependencies installed with composer between builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ php:
   - 7.1
   - nightly
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 before_script:
   - composer install
 


### PR DESCRIPTION
This PR

* [x] caches dependencies installed with `composer`s between Travis CI builds

💁‍♂️ For reference, see 

* https://docs.travis-ci.com/user/caching/#Arbitrary-directories
* https://getcomposer.org/doc/06-config.md#cache-dir
