### PR TITLE
Enhancement: Keep packages sorted without specifying --sort-packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,12 @@
         "lcobucci/jose-parsing": "~2.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
-        "squizlabs/php_codesniffer": "^2.7",
+        "mdanter/ecc": "^0.4",
+        "mikey179/vfsStream": "^1.6",
         "phpmd/phpmd": "^2.5",
         "phpunit/php-invoker": "^1.1",
-        "mikey179/vfsStream": "^1.6",
-        "mdanter/ecc": "^0.4"
+        "phpunit/phpunit": "^6.0",
+        "squizlabs/php_codesniffer": "^2.7"
     },
     "suggest":{
         "mdanter/ecc": "Required to use Elliptic Curves based algorithms."
@@ -47,7 +47,8 @@
         }
     },
     "config": {
-        "preferred-install": "dist"
+        "preferred-install": "dist",
+        "sort-packages": true
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
This PR

* [x] keeps packages in `composer.json` sorted (without the need to specify the `--sort-packages` option)

💁‍♂️ For reference, see https://getcomposer.org/doc/06-config.md#sort-packages.