### PR TITLE
fix two dot token string returned by getPayload() function according to RFC

### DIFF
--- a/src/Token.php
+++ b/src/Token.php
@@ -263,7 +263,7 @@ class Token
      */
     public function getPayload()
     {
-        return $this->payload[0] . '.' . $this->payload[1];
+        return implode('.', $this->payload);
     }
 
     /**


### PR DESCRIPTION
Current function getPayload() in the Token class return 1 dotted string.

See p8
[https://tools.ietf.org/html/rfc7519](https://tools.ietf.org/html/rfc7519)