### PR TITLE
Add claims in token interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ phpunit.xml
 composer.lock
 humbuglog.txt
 coverage
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ phpunit.xml
 composer.lock
 humbuglog.txt
 coverage
-.idea

--- a/src/Token.php
+++ b/src/Token.php
@@ -26,6 +26,11 @@ interface Token
     public function headers(): DataSet;
 
     /**
+     * Returns the token claims
+     */
+    public function claims(): DataSet;
+
+    /**
      * Returns if the token is allowed to be used by the audience
      */
     public function isPermittedFor(string $audience): bool;


### PR DESCRIPTION
`claims` method was added in `Token` interface.
It's not available to use abstraction in auth library, because you need to get claims about user from parsed token for auth.

Signed-off-by: Artemiy Ryabinkov <getlag@ya.ru>