### PR TITLE
Switched public and final to match PSR2

### DIFF
--- a/test/performance/SignerBench.php
+++ b/test/performance/SignerBench.php
@@ -35,7 +35,7 @@ abstract class SignerBench
      */
     private $signature;
 
-    public final function init(): void
+    final public function init(): void
     {
         $this->signer          = $this->signer();
         $this->signingKey      = $this->signingKey();
@@ -43,12 +43,12 @@ abstract class SignerBench
         $this->signature       = $this->signer->sign(self::PAYLOAD, $this->signingKey);
     }
 
-    public final function benchSignature(): void
+    final public function benchSignature(): void
     {
         $this->signer->sign(self::PAYLOAD, $this->signingKey);
     }
 
-    public final function benchVerification(): void
+    final public function benchVerification(): void
     {
         $this->signer->verify($this->signature, self::PAYLOAD, $this->verificationKey);
     }


### PR DESCRIPTION
Super minor PR:

final should be declared before public according to PSR2:
 - `Visibility MUST be declared on all properties and methods; abstract and final MUST be declared before the visibility; static MUST be declared after the visibility.` (https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)

Just came across it while scanning the code (super nice code base btw).

PS, I'm very new to open-source so please let me know if I broke some kind of contributing rule (I think I've done everything in the contributing doc)