### PR TITLE
Add CS checking to build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 humbuglog.txt
 coverage
 phpcs.xml
+/.phpcs.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,10 @@ jobs:
       script:
         - ./vendor/bin/phpbench run -l dots --report aggregate
 
+    - stage: Code-style
+      script:
+        - ./vendor/bin/phpcs
+
 #    - stage: Mutation
 #      before_script:
 #        - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{.disabled,}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,15 +1,32 @@
 <?xml version="1.0"?>
-<ruleset name="JWT style">
-    <description>The coding standard for lcobucci/jwt.</description>
-
-    <arg name="basepath" value="."/>
-    <arg name="extensions" value="php"/>
+<ruleset>
+    <arg name="basepath" value="." />
+    <arg name="extensions" value="php" />
     <arg name="parallel" value="80" />
     <arg name="colors" />
-    <arg value="np"/>
+    <arg name="cache" value=".phpcs.cache" />
+    <arg value="p" />
 
     <file>src</file>
     <file>test</file>
 
     <rule ref="PSR2"/>
+
+    <rule ref="Generic.Formatting.MultipleStatementAlignment">
+        <properties>
+            <property name="error" value="true"/>
+        </properties>
+    </rule>
+
+    <rule ref="Generic.Formatting.SpaceAfterCast" />
+    <rule ref="Generic.Formatting.SpaceAfterNot" />
+    <rule ref="Generic.Arrays.DisallowLongArraySyntax" />
+
+    <rule ref="Squiz.Strings.ConcatenationSpacing">
+        <properties>
+            <property name="spacing" value="1"/>
+            <property name="ignoreNewlines" value="true"/>
+        </properties>
+    </rule>
 </ruleset>
+

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -84,8 +84,8 @@ final class Configuration
         Key $signingKey,
         Key $verificationKey
     ) {
-        $this->signer = $signer;
-        $this->signingKey = $signingKey;
+        $this->signer          = $signer;
+        $this->signingKey      = $signingKey;
         $this->verificationKey = $verificationKey;
     }
 

--- a/src/Signer/Ecdsa.php
+++ b/src/Signer/Ecdsa.php
@@ -44,7 +44,7 @@ abstract class Ecdsa implements Signer
 
     public function __construct(EccAdapter $adapter, KeyParser $keyParser)
     {
-        $this->adapter = $adapter;
+        $this->adapter   = $adapter;
         $this->keyParser = $keyParser;
     }
 

--- a/src/Signer/Ecdsa/EccAdapter.php
+++ b/src/Signer/Ecdsa/EccAdapter.php
@@ -71,9 +71,9 @@ class EccAdapter
         SignatureSerializer $serializer,
         RandomNumberGeneratorInterface $numberGenerator
     ) {
-        $this->signer = $signer;
-        $this->nistCurve = $nistCurve;
-        $this->serializer = $serializer;
+        $this->signer          = $signer;
+        $this->nistCurve       = $nistCurve;
+        $this->serializer      = $serializer;
         $this->numberGenerator = $numberGenerator;
     }
 
@@ -118,7 +118,7 @@ class EccAdapter
 
     private function generatorPoint(string $algorithm): GeneratorPoint
     {
-        if (!array_key_exists($algorithm, self::GENERATOR_POINTS)) {
+        if (! array_key_exists($algorithm, self::GENERATOR_POINTS)) {
             throw new InvalidArgumentException('Unknown algorithm');
         }
 

--- a/src/Signer/Ecdsa/KeyParser.php
+++ b/src/Signer/Ecdsa/KeyParser.php
@@ -55,7 +55,7 @@ class KeyParser
         PrivateKeySerializerInterface $privateKeySerializer,
         PublicKeySerializerInterface $publicKeySerializer
     ) {
-        $this->publicKeySerializer = $publicKeySerializer;
+        $this->publicKeySerializer  = $publicKeySerializer;
         $this->privateKeySerializer = $privateKeySerializer;
     }
 

--- a/src/Signer/Key.php
+++ b/src/Signer/Key.php
@@ -62,7 +62,7 @@ final class Key
     {
         $file = substr($content, 7);
 
-        if (!is_readable($file)) {
+        if (! is_readable($file)) {
             throw new \InvalidArgumentException('You must inform a valid key file');
         }
 

--- a/src/Signer/Rsa.php
+++ b/src/Signer/Rsa.php
@@ -30,7 +30,7 @@ abstract class Rsa implements Signer
 
         $signature = '';
 
-        if (!openssl_sign($payload, $signature, $key, $this->getAlgorithm())) {
+        if (! openssl_sign($payload, $signature, $key, $this->getAlgorithm())) {
             throw new InvalidArgumentException(
                 'There was an error while creating the signature: ' . openssl_error_string()
             );
@@ -67,7 +67,7 @@ abstract class Rsa implements Signer
 
         $details = openssl_pkey_get_details($key);
 
-        if (!isset($details['key']) || $details['type'] !== OPENSSL_KEYTYPE_RSA) {
+        if (! isset($details['key']) || $details['type'] !== OPENSSL_KEYTYPE_RSA) {
             throw new InvalidArgumentException('This key is not compatible with RSA signatures');
         }
     }

--- a/src/Token/Builder.php
+++ b/src/Token/Builder.php
@@ -59,7 +59,7 @@ final class Builder implements BuilderInterface
     {
         $audiences = $this->claims[RegisteredClaims::AUDIENCE] ?? [];
 
-        if (!in_array($audience, $audiences)) {
+        if (! in_array($audience, $audiences)) {
             $audiences[] = $audience;
         }
 
@@ -155,13 +155,13 @@ final class Builder implements BuilderInterface
      */
     public function getToken(Signer $signer, Key $key): Plain
     {
-        $headers = $this->headers;
+        $headers        = $this->headers;
         $headers['alg'] = $signer->getAlgorithmId();
 
         $encodedHeaders = $this->encode($headers);
-        $encodedClaims = $this->encode($this->formatClaims($this->claims));
+        $encodedClaims  = $this->encode($this->formatClaims($this->claims));
 
-        $signature = $signer->sign($encodedHeaders . '.' . $encodedClaims, $key);
+        $signature        = $signer->sign($encodedHeaders . '.' . $encodedClaims, $key);
         $encodedSignature = $this->encoder->base64UrlEncode($signature);
 
         return new Plain(
@@ -173,7 +173,7 @@ final class Builder implements BuilderInterface
 
     private function formatClaims(array $claims): array
     {
-        if (isset($claims[RegisteredClaims::AUDIENCE][0]) && !isset($claims[RegisteredClaims::AUDIENCE][1])) {
+        if (isset($claims[RegisteredClaims::AUDIENCE][0]) && ! isset($claims[RegisteredClaims::AUDIENCE][1])) {
             $claims[RegisteredClaims::AUDIENCE] = $claims[RegisteredClaims::AUDIENCE][0];
         }
 
@@ -189,7 +189,7 @@ final class Builder implements BuilderInterface
      */
     private function convertDate(DateTimeImmutable $date)
     {
-        $seconds = $date->format('U');
+        $seconds      = $date->format('U');
         $microseconds = $date->format('u');
 
         if ((int) $microseconds === 0) {

--- a/src/Token/DataSet.php
+++ b/src/Token/DataSet.php
@@ -28,7 +28,7 @@ final class DataSet
 
     public function __construct(array $data, string $encoded)
     {
-        $this->data = $data;
+        $this->data    = $data;
         $this->encoded = $encoded;
     }
 

--- a/src/Token/Parser.php
+++ b/src/Token/Parser.php
@@ -118,7 +118,7 @@ final class Parser implements ParserInterface
      */
     private function parseSignature(array $header, string $data): Signature
     {
-        if ($data === '' || !isset($header['alg']) || $header['alg'] === 'none') {
+        if ($data === '' || ! isset($header['alg']) || $header['alg'] === 'none') {
             return Signature::fromEmptyData();
         }
 

--- a/src/Token/Plain.php
+++ b/src/Token/Plain.php
@@ -46,8 +46,8 @@ final class Plain implements TokenInterface
         DataSet $claims,
         Signature $signature
     ) {
-        $this->headers = $headers;
-        $this->claims = $claims;
+        $this->headers   = $headers;
+        $this->claims    = $claims;
         $this->signature = $signature;
     }
 
@@ -136,7 +136,7 @@ final class Plain implements TokenInterface
      */
     public function isExpired(DateTimeInterface $now): bool
     {
-        if (!$this->claims->has(RegisteredClaims::EXPIRATION_TIME)) {
+        if (! $this->claims->has(RegisteredClaims::EXPIRATION_TIME)) {
             return false;
         }
 

--- a/src/Token/Signature.php
+++ b/src/Token/Signature.php
@@ -34,7 +34,7 @@ final class Signature
 
     public function __construct(string $hash, string $encoded)
     {
-        $this->hash = $hash;
+        $this->hash    = $hash;
         $this->encoded = $encoded;
     }
 

--- a/src/Validation/Constraint/IdentifiedBy.php
+++ b/src/Validation/Constraint/IdentifiedBy.php
@@ -32,7 +32,7 @@ final class IdentifiedBy implements Constraint
      */
     public function assert(Token $token): void
     {
-        if (!$token->isIdentifiedBy($this->id)) {
+        if (! $token->isIdentifiedBy($this->id)) {
             throw new ConstraintViolationException(
                 'The token is not identified with the expected ID'
             );

--- a/src/Validation/Constraint/IssuedBy.php
+++ b/src/Validation/Constraint/IssuedBy.php
@@ -34,7 +34,7 @@ final class IssuedBy implements Constraint
      */
     public function assert(Token $token): void
     {
-        if (!$token->hasBeenIssuedBy(...$this->issuers)) {
+        if (! $token->hasBeenIssuedBy(...$this->issuers)) {
             throw new ConstraintViolationException(
                 'The token was not issued by the given issuers'
             );

--- a/src/Validation/Constraint/PermittedFor.php
+++ b/src/Validation/Constraint/PermittedFor.php
@@ -34,7 +34,7 @@ final class PermittedFor implements Constraint
      */
     public function assert(Token $token): void
     {
-        if (!$token->isPermittedFor($this->audience)) {
+        if (! $token->isPermittedFor($this->audience)) {
             throw new ConstraintViolationException(
                 'The token is not allowed to be used by this audience'
             );

--- a/src/Validation/Constraint/RelatedTo.php
+++ b/src/Validation/Constraint/RelatedTo.php
@@ -32,7 +32,7 @@ final class RelatedTo implements Constraint
      */
     public function assert(Token $token): void
     {
-        if (!$token->isRelatedTo($this->subject)) {
+        if (! $token->isRelatedTo($this->subject)) {
             throw new ConstraintViolationException(
                 'The token is not related to the expected subject'
             );

--- a/src/Validation/Constraint/SignedWith.php
+++ b/src/Validation/Constraint/SignedWith.php
@@ -33,7 +33,7 @@ final class SignedWith implements Constraint
     public function __construct(Signer $signer, Signer\Key $key)
     {
         $this->signer = $signer;
-        $this->key = $key;
+        $this->key    = $key;
     }
 
     /**
@@ -41,7 +41,7 @@ final class SignedWith implements Constraint
      */
     public function assert(Token $token): void
     {
-        if (!$token instanceof Token\Plain) {
+        if (! $token instanceof Token\Plain) {
             throw new ConstraintViolationException('You should pass a plain token');
         }
 
@@ -49,7 +49,7 @@ final class SignedWith implements Constraint
             throw new ConstraintViolationException('Token signer mismatch');
         }
 
-        if (!$this->signer->verify($token->signature()->hash(), $token->payload(), $this->key)) {
+        if (! $this->signer->verify($token->signature()->hash(), $token->payload(), $this->key)) {
             throw new ConstraintViolationException('Token signature mismatch');
         }
     }

--- a/src/Validation/InvalidTokenException.php
+++ b/src/Validation/InvalidTokenException.php
@@ -23,7 +23,7 @@ final class InvalidTokenException extends Exception
 
     public static function fromViolations(ConstraintViolationException ...$violations): self
     {
-        $exception = new self(self::buildMessage($violations));
+        $exception             = new self(self::buildMessage($violations));
         $exception->violations = $violations;
 
         return $exception;
@@ -38,7 +38,7 @@ final class InvalidTokenException extends Exception
             $violations
         );
 
-        $message = "The token violates some mandatory constraints, details:\n";
+        $message  = "The token violates some mandatory constraints, details:\n";
         $message .= implode("\n", $violations);
 
         return $message;

--- a/test/functional/EcdsaTokenTest.php
+++ b/test/functional/EcdsaTokenTest.php
@@ -116,7 +116,7 @@ class EcdsaTokenTest extends \PHPUnit\Framework\TestCase
      */
     public function builderCanGenerateAToken(): Token
     {
-        $user = ['name' => 'testing', 'email' => 'testing@abc.com'];
+        $user    = ['name' => 'testing', 'email' => 'testing@abc.com'];
         $builder = $this->config->createBuilder();
 
         $token = $builder->identifiedBy('1')
@@ -316,7 +316,7 @@ class EcdsaTokenTest extends \PHPUnit\Framework\TestCase
     public function everythingShouldWorkWithAKeyWithParams(): void
     {
         $builder = $this->config->createBuilder();
-        $signer = $this->config->getSigner();
+        $signer  = $this->config->getSigner();
 
         $token = $builder->identifiedBy('1')
                          ->permittedFor('http://client.abc.com')
@@ -365,7 +365,7 @@ class EcdsaTokenTest extends \PHPUnit\Framework\TestCase
                . 'mZudf1zCUZ8/4eodlHU=' . PHP_EOL
                . '-----END PUBLIC KEY-----';
 
-        $token = $this->config->getParser()->parse((string) $data);
+        $token      = $this->config->getParser()->parse((string) $data);
         $constraint = new SignedWith(Sha512::create(), new Key($key));
 
         self::assertTrue($this->config->getValidator()->validate($token, $constraint));

--- a/test/functional/HmacTokenTest.php
+++ b/test/functional/HmacTokenTest.php
@@ -50,7 +50,7 @@ class HmacTokenTest extends \PHPUnit\Framework\TestCase
      */
     public function builderCanGenerateAToken(): Token
     {
-        $user = ['name' => 'testing', 'email' => 'testing@abc.com'];
+        $user    = ['name' => 'testing', 'email' => 'testing@abc.com'];
         $builder = $this->config->createBuilder();
 
         $token = $builder->identifiedBy('1')
@@ -191,7 +191,7 @@ class HmacTokenTest extends \PHPUnit\Framework\TestCase
         $data = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXUyJ9.eyJoZWxsbyI6IndvcmxkIn0.Rh'
                 . '7AEgqCB7zae1PkgIlvOpeyw9Ab8NGTbeOH7heHO0o';
 
-        $token = $this->config->getParser()->parse((string) $data);
+        $token      = $this->config->getParser()->parse((string) $data);
         $constraint = new SignedWith($this->config->getSigner(), $this->config->getVerificationKey());
 
         self::assertTrue($this->config->getValidator()->validate($token, $constraint));

--- a/test/functional/MaliciousTamperingPreventionTest.php
+++ b/test/functional/MaliciousTamperingPreventionTest.php
@@ -108,7 +108,7 @@ final class MaliciousTamperingPreventionTest extends \PHPUnit\Framework\TestCase
      */
     private function createMaliciousToken(string $token): string
     {
-        $dec = new Parser();
+        $dec     = new Parser();
         $asplode = explode('.', $token);
 
         // The user is lying; we insist that we're using HMAC-SHA512, with the

--- a/test/functional/RsaTokenTest.php
+++ b/test/functional/RsaTokenTest.php
@@ -107,7 +107,7 @@ class RsaTokenTest extends \PHPUnit\Framework\TestCase
      */
     public function builderCanGenerateAToken(): Token
     {
-        $user = ['name' => 'testing', 'email' => 'testing@abc.com'];
+        $user    = ['name' => 'testing', 'email' => 'testing@abc.com'];
         $builder = $this->config->createBuilder();
 
         $token = $builder->identifiedBy('1')
@@ -284,7 +284,7 @@ class RsaTokenTest extends \PHPUnit\Framework\TestCase
                 . 'nJCupP-Lqh4TmIhftIimSCgLNmJg80wyrpUEfZYReE7hPuEmY0ClTqAGIMQoNS'
                 . '98ljwDxwhfbSuL2tAdbV4DekbTpWzspe3dOJ7RSzmPKVZ6NoezaIazKqyqkmHZfcMaHI1lQeGia6LTbHU1bp0gINi74Vw';
 
-        $token = $this->config->getParser()->parse((string) $data);
+        $token      = $this->config->getParser()->parse((string) $data);
         $constraint = new SignedWith($this->config->getSigner(), $this->config->getVerificationKey());
 
         self::assertTrue($this->config->getValidator()->validate($token, $constraint));

--- a/test/functional/UnsignedTokenTest.php
+++ b/test/functional/UnsignedTokenTest.php
@@ -54,7 +54,7 @@ class UnsignedTokenTest extends \PHPUnit\Framework\TestCase
      */
     public function builderCanGenerateAToken(): Token
     {
-        $user = ['name' => 'testing', 'email' => 'testing@abc.com'];
+        $user    = ['name' => 'testing', 'email' => 'testing@abc.com'];
         $builder = $this->config->createBuilder();
 
         $expiration = new DateTimeImmutable('@' . (self::CURRENT_TIME + 3000));
@@ -186,13 +186,13 @@ class UnsignedTokenTest extends \PHPUnit\Framework\TestCase
         {
             public function assert(Token $token): void
             {
-                if (!$token instanceof Token\Plain) {
+                if (! $token instanceof Token\Plain) {
                     throw new ConstraintViolationException();
                 }
 
                 $claims = $token->claims();
 
-                if (!$claims->has('user')) {
+                if (! $claims->has('user')) {
                     throw new ConstraintViolationException();
                 }
 

--- a/test/performance/SignerBench.php
+++ b/test/performance/SignerBench.php
@@ -13,7 +13,9 @@ use PhpBench\Benchmark\Metadata\Annotations\Revs;
  */
 abstract class SignerBench
 {
-    private const PAYLOAD = "It\xe2\x80\x99s a dangerous business, Frodo, going out your door. You step onto the road, and if you don't keep your feet, there\xe2\x80\x99s no knowing where you might be swept off to.";
+    private const PAYLOAD = "It\xe2\x80\x99s a dangerous business, Frodo, going out your door. You step onto the road,"
+                          . " and if you don't keep your feet, there\xe2\x80\x99s no knowing where you might be swept"
+                          . " off to.";
 
     /**
      * @var Signer

--- a/test/unit/ConfigurationTest.php
+++ b/test/unit/ConfigurationTest.php
@@ -48,10 +48,10 @@ final class ConfigurationTest extends \PHPUnit\Framework\TestCase
      */
     public function createDependencies(): void
     {
-        $this->signer = $this->createMock(Signer::class);
-        $this->encoder = $this->createMock(Parsing\Encoder::class);
-        $this->decoder = $this->createMock(Parsing\Decoder::class);
-        $this->parser = $this->createMock(Parser::class);
+        $this->signer    = $this->createMock(Signer::class);
+        $this->encoder   = $this->createMock(Parsing\Encoder::class);
+        $this->decoder   = $this->createMock(Parsing\Decoder::class);
+        $this->parser    = $this->createMock(Parser::class);
         $this->validator = $this->createMock(Validator::class);
     }
 
@@ -65,7 +65,7 @@ final class ConfigurationTest extends \PHPUnit\Framework\TestCase
      */
     public function forAsymmetricSignerShouldConfigureSignerAndBothKeys(): void
     {
-        $signingKey = new Key('private');
+        $signingKey      = new Key('private');
         $verificationKey = new Key('public');
 
         $config = Configuration::forAsymmetricSigner($this->signer, $signingKey, $verificationKey);
@@ -85,7 +85,7 @@ final class ConfigurationTest extends \PHPUnit\Framework\TestCase
      */
     public function forSymmetricSignerShouldConfigureSignerAndBothKeys(): void
     {
-        $key = new Key('private');
+        $key    = new Key('private');
         $config = Configuration::forSymmetricSigner($this->signer, $key);
 
         self::assertAttributeSame($this->signer, 'signer', $config);
@@ -103,7 +103,7 @@ final class ConfigurationTest extends \PHPUnit\Framework\TestCase
      */
     public function forUnsecuredSignerShouldConfigureSignerAndBothKeys(): void
     {
-        $key = new Key('');
+        $key    = new Key('');
         $config = Configuration::forUnsecuredSigner();
 
         self::assertAttributeInstanceOf(None::class, 'signer', $config);
@@ -126,7 +126,7 @@ final class ConfigurationTest extends \PHPUnit\Framework\TestCase
      */
     public function createBuilderShouldCreateABuilderWithDefaultEncoderAndClaimFactory(): void
     {
-        $config = Configuration::forUnsecuredSigner();
+        $config  = Configuration::forUnsecuredSigner();
         $builder = $config->createBuilder();
 
         self::assertInstanceOf(Builder::class, $builder);
@@ -250,7 +250,7 @@ final class ConfigurationTest extends \PHPUnit\Framework\TestCase
      */
     public function getSigningKeyShouldReturnTheConfiguredKey(): void
     {
-        $signingKey = new Key('private');
+        $signingKey      = new Key('private');
         $verificationKey = new Key('public');
 
         $config = Configuration::forAsymmetricSigner($this->signer, $signingKey, $verificationKey);
@@ -269,7 +269,7 @@ final class ConfigurationTest extends \PHPUnit\Framework\TestCase
      */
     public function getVerificationKeyShouldReturnTheConfiguredKey(): void
     {
-        $signingKey = new Key('private');
+        $signingKey      = new Key('private');
         $verificationKey = new Key('public');
 
         $config = Configuration::forAsymmetricSigner($this->signer, $signingKey, $verificationKey);
@@ -289,7 +289,7 @@ final class ConfigurationTest extends \PHPUnit\Framework\TestCase
      */
     public function getValidatorShouldReturnTheDefaultWhenItWasNotConfigured(): void
     {
-        $config = Configuration::forUnsecuredSigner();
+        $config    = Configuration::forUnsecuredSigner();
         $validator = $config->getValidator();
 
         self::assertNotSame($this->validator, $validator);

--- a/test/unit/Signer/Ecdsa/BaseTestCase.php
+++ b/test/unit/Signer/Ecdsa/BaseTestCase.php
@@ -30,7 +30,7 @@ abstract class BaseTestCase extends \PHPUnit\Framework\TestCase
      */
     public function createDependencies(): void
     {
-        $this->adapter = $this->createMock(EccAdapter::class);
+        $this->adapter   = $this->createMock(EccAdapter::class);
         $this->keyParser = $this->createMock(KeyParser::class);
     }
 }

--- a/test/unit/Signer/Ecdsa/EccAdapterTest.php
+++ b/test/unit/Signer/Ecdsa/EccAdapterTest.php
@@ -54,10 +54,10 @@ final class EccAdapterTest extends \PHPUnit\Framework\TestCase
      */
     public function createDependencies(): void
     {
-        $this->mathInterface = $this->createMock(GmpMathInterface::class);
-        $this->signer = $this->createMock(Signer::class);
-        $this->nistCurve = $this->createMock(NistCurve::class);
-        $this->serializer = $this->createMock(SignatureSerializer::class);
+        $this->mathInterface   = $this->createMock(GmpMathInterface::class);
+        $this->signer          = $this->createMock(Signer::class);
+        $this->nistCurve       = $this->createMock(NistCurve::class);
+        $this->serializer      = $this->createMock(SignatureSerializer::class);
         $this->numberGenerator = $this->createMock(RandomNumberGeneratorInterface::class);
     }
 
@@ -103,12 +103,12 @@ final class EccAdapterTest extends \PHPUnit\Framework\TestCase
      */
     public function createHashShouldReturnASerializedSignature(): void
     {
-        $key = $this->createMock(PrivateKeyInterface::class);
-        $point = $this->createMock(GeneratorPoint::class);
+        $key       = $this->createMock(PrivateKeyInterface::class);
+        $point     = $this->createMock(GeneratorPoint::class);
         $signature = $this->createMock(SignatureInterface::class);
 
-        $order = gmp_init(1, 10);
-        $randomK = gmp_init(2, 10);
+        $order       = gmp_init(1, 10);
+        $randomK     = gmp_init(2, 10);
         $signingHash = gmp_init(3, 10);
 
         $key->method('getPoint')->willReturn($point);
@@ -146,8 +146,8 @@ final class EccAdapterTest extends \PHPUnit\Framework\TestCase
      */
     public function verifyHashShouldReturnTheSignerResult(): void
     {
-        $key = $this->createMock(PublicKeyInterface::class);
-        $signature = $this->createMock(SignatureInterface::class);
+        $key         = $this->createMock(PublicKeyInterface::class);
+        $signature   = $this->createMock(SignatureInterface::class);
         $signingHash = gmp_init(1, 10);
 
         $this->serializer->expects($this->once())
@@ -193,7 +193,7 @@ final class EccAdapterTest extends \PHPUnit\Framework\TestCase
      */
     public function createSigningHashShouldReturnTheSignerResult(): void
     {
-        $signingHash = gmp_init(1, 10);
+        $signingHash    = gmp_init(1, 10);
         $generatorPoint = $this->createMock(GeneratorPoint::class);
 
         $this->nistCurve->expects($this->once())

--- a/test/unit/Signer/Ecdsa/KeyParserTest.php
+++ b/test/unit/Signer/Ecdsa/KeyParserTest.php
@@ -42,9 +42,9 @@ final class KeyParserTest extends \PHPUnit\Framework\TestCase
      */
     public function createDependencies(): void
     {
-        $this->adapter = $this->createMock(GmpMathInterface::class);
+        $this->adapter              = $this->createMock(GmpMathInterface::class);
         $this->privateKeySerializer = $this->createMock(PrivateKeySerializerInterface::class);
-        $this->publicKeySerializer = $this->createMock(PublicKeySerializerInterface::class);
+        $this->publicKeySerializer  = $this->createMock(PublicKeySerializerInterface::class);
     }
 
     /**

--- a/test/unit/Signer/EcdsaTest.php
+++ b/test/unit/Signer/EcdsaTest.php
@@ -60,9 +60,9 @@ final class EcdsaTest extends BaseTestCase
      */
     public function signShouldReturnAHashUsingPrivateKey(): void
     {
-        $signer = $this->getSigner();
-        $key = new Key('testing');
-        $privateKey = $this->createMock(PrivateKeyInterface::class);
+        $signer      = $this->getSigner();
+        $key         = new Key('testing');
+        $privateKey  = $this->createMock(PrivateKeyInterface::class);
         $signingHash = gmp_init(10, 10);
 
         $this->keyParser->expects($this->once())
@@ -93,9 +93,9 @@ final class EcdsaTest extends BaseTestCase
      */
     public function verifyShouldDelegateToEcdsaSignerUsingPublicKey(): void
     {
-        $signer = $this->getSigner();
-        $key = new Key('testing');
-        $publicKey = $this->createMock(PublicKeyInterface::class);
+        $signer      = $this->getSigner();
+        $key         = new Key('testing');
+        $publicKey   = $this->createMock(PublicKeyInterface::class);
         $signingHash = gmp_init(10, 10);
 
         $this->keyParser->expects($this->once())

--- a/test/unit/Signer/RsaTest.php
+++ b/test/unit/Signer/RsaTest.php
@@ -33,7 +33,7 @@ final class RsaTest extends \PHPUnit\Framework\TestCase
     {
         $payload = 'testing';
 
-        $signer = $this->getSigner();
+        $signer    = $this->getSigner();
         $signature = $signer->sign($payload, self::$rsaKeys['private']);
 
         $publicKey = openssl_get_publickey(self::$rsaKeys['public']->getContent());
@@ -114,9 +114,9 @@ KEY;
      */
     public function verifyShouldReturnAValidOpensslSignature(): void
     {
-        $payload = 'testing';
+        $payload    = 'testing';
         $privateKey = openssl_get_privatekey(self::$rsaKeys['private']->getContent());
-        $signature = '';
+        $signature  = '';
         openssl_sign($payload, $signature, $privateKey, OPENSSL_ALGO_SHA256);
 
         $signer = $this->getSigner();

--- a/test/unit/Token/BuilderTest.php
+++ b/test/unit/Token/BuilderTest.php
@@ -36,7 +36,7 @@ final class BuilderTest extends \PHPUnit\Framework\TestCase
     public function initializeDependencies(): void
     {
         $this->encoder = $this->createMock(Encoder::class);
-        $this->signer = $this->createMock(Signer::class);
+        $this->signer  = $this->createMock(Signer::class);
         $this->signer->method('getAlgorithmId')->willReturn('RS256');
     }
 
@@ -414,10 +414,10 @@ final class BuilderTest extends \PHPUnit\Framework\TestCase
     {
         $this->signer->method('sign')->willReturn('testing');
 
-        $issuedAt = new DateTimeImmutable('@1487285080');
+        $issuedAt   = new DateTimeImmutable('@1487285080');
         $expiration = DateTimeImmutable::createFromFormat('U.u', '1487285080.123456');
-        $headers = ['typ' => 'JWT', 'alg' => 'RS256'];
-        $claims = ['iat' => 1487285080, 'exp' => '1487285080.123456', 'aud' => 'test', 'test' => 123];
+        $headers    = ['typ' => 'JWT', 'alg' => 'RS256'];
+        $claims     = ['iat' => 1487285080, 'exp' => '1487285080.123456', 'aud' => 'test', 'test' => 123];
 
         $this->encoder->expects($this->exactly(2))
                       ->method('jsonEncode')

--- a/test/unit/Token/DataSetTest.php
+++ b/test/unit/Token/DataSetTest.php
@@ -89,7 +89,7 @@ final class DataSetTest extends \PHPUnit\Framework\TestCase
     public function allShouldReturnAllConfiguredItems(): void
     {
         $items = ['one' => 1, 'two' => 2];
-        $set = new DataSet($items, 'one=1');
+        $set   = new DataSet($items, 'one=1');
 
         self::assertEquals($items, $set->all());
     }

--- a/test/unit/Token/ParserTest.php
+++ b/test/unit/Token/ParserTest.php
@@ -150,10 +150,10 @@ final class ParserTest extends \PHPUnit\Framework\TestCase
                       ->willReturn([RegisteredClaims::AUDIENCE => 'test']);
 
         $parser = $this->createParser();
-        $token = $parser->parse('a.b.');
+        $token  = $parser->parse('a.b.');
 
         $headers = new DataSet(['typ' => 'JWT', 'alg' => 'none'], 'a');
-        $claims = new DataSet([RegisteredClaims::AUDIENCE => ['test']], 'b');
+        $claims  = new DataSet([RegisteredClaims::AUDIENCE => ['test']], 'b');
 
         self::assertAttributeEquals($headers, 'headers', $token);
         self::assertAttributeEquals($claims, 'claims', $token);
@@ -197,10 +197,10 @@ final class ParserTest extends \PHPUnit\Framework\TestCase
                       ->willReturn([RegisteredClaims::AUDIENCE => 'test']);
 
         $parser = $this->createParser();
-        $token = $parser->parse('a.b.');
+        $token  = $parser->parse('a.b.');
 
         $headers = new DataSet(['typ' => 'JWT', 'alg' => 'none', RegisteredClaims::AUDIENCE => 'test'], 'a');
-        $claims = new DataSet([RegisteredClaims::AUDIENCE => ['test']], 'b');
+        $claims  = new DataSet([RegisteredClaims::AUDIENCE => ['test']], 'b');
 
         self::assertAttributeEquals($headers, 'headers', $token);
         self::assertAttributeEquals($claims, 'claims', $token);
@@ -244,10 +244,10 @@ final class ParserTest extends \PHPUnit\Framework\TestCase
                       ->willReturn([RegisteredClaims::AUDIENCE => 'test']);
 
         $parser = $this->createParser();
-        $token = $parser->parse('a.b.c');
+        $token  = $parser->parse('a.b.c');
 
         $headers = new DataSet(['typ' => 'JWT'], 'a');
-        $claims = new DataSet([RegisteredClaims::AUDIENCE => ['test']], 'b');
+        $claims  = new DataSet([RegisteredClaims::AUDIENCE => ['test']], 'b');
 
         self::assertAttributeEquals($headers, 'headers', $token);
         self::assertAttributeEquals($claims, 'claims', $token);
@@ -291,10 +291,10 @@ final class ParserTest extends \PHPUnit\Framework\TestCase
                       ->willReturn([RegisteredClaims::AUDIENCE => 'test']);
 
         $parser = $this->createParser();
-        $token = $parser->parse('a.b.c');
+        $token  = $parser->parse('a.b.c');
 
         $headers = new DataSet(['typ' => 'JWT', 'alg' => 'none'], 'a');
-        $claims = new DataSet([RegisteredClaims::AUDIENCE => ['test']], 'b');
+        $claims  = new DataSet([RegisteredClaims::AUDIENCE => ['test']], 'b');
 
         self::assertAttributeEquals($headers, 'headers', $token);
         self::assertAttributeEquals($claims, 'claims', $token);
@@ -343,10 +343,10 @@ final class ParserTest extends \PHPUnit\Framework\TestCase
                       ->willReturn('c_dec');
 
         $parser = $this->createParser();
-        $token = $parser->parse('a.b.c');
+        $token  = $parser->parse('a.b.c');
 
-        $headers = new DataSet(['typ' => 'JWT', 'alg' => 'HS256'], 'a');
-        $claims = new DataSet([RegisteredClaims::AUDIENCE => ['test']], 'b');
+        $headers   = new DataSet(['typ' => 'JWT', 'alg' => 'HS256'], 'a');
+        $claims    = new DataSet([RegisteredClaims::AUDIENCE => ['test']], 'b');
         $signature = new Signature('c_dec', 'c');
 
         self::assertAttributeEquals($headers, 'headers', $token);

--- a/test/unit/Token/PlainTest.php
+++ b/test/unit/Token/PlainTest.php
@@ -37,8 +37,8 @@ final class PlainTest extends \PHPUnit\Framework\TestCase
      */
     public function createDependencies(): void
     {
-        $this->headers = new DataSet(['alg' => 'none'], 'headers');
-        $this->claims = new DataSet([], 'claims');
+        $this->headers   = new DataSet(['alg' => 'none'], 'headers');
+        $this->claims    = new DataSet([], 'claims');
         $this->signature = new Signature('hash', 'signature');
     }
 
@@ -416,7 +416,7 @@ final class PlainTest extends \PHPUnit\Framework\TestCase
      */
     public function hasBeenIssuedBeforeShouldReturnTrueWhenIssueTimeIsBeforeThanNow(): void
     {
-        $now = new DateTimeImmutable();
+        $now   = new DateTimeImmutable();
         $token = $this->createToken(
             null,
             new DataSet([RegisteredClaims::ISSUED_AT => $now->modify('-100 seconds')], '')
@@ -436,7 +436,7 @@ final class PlainTest extends \PHPUnit\Framework\TestCase
      */
     public function hasBeenIssuedBeforeShouldReturnTrueWhenIssueTimeIsEqualsToNow(): void
     {
-        $now = new DateTimeImmutable();
+        $now   = new DateTimeImmutable();
         $token = $this->createToken(
             null,
             new DataSet([RegisteredClaims::ISSUED_AT => $now], '')
@@ -456,7 +456,7 @@ final class PlainTest extends \PHPUnit\Framework\TestCase
      */
     public function hasBeenIssuedBeforeShouldReturnFalseWhenIssueTimeIsGreaterThanNow(): void
     {
-        $now = new DateTimeImmutable();
+        $now   = new DateTimeImmutable();
         $token = $this->createToken(
             null,
             new DataSet([RegisteredClaims::ISSUED_AT => $now->modify('+100 seconds')], '')
@@ -492,7 +492,7 @@ final class PlainTest extends \PHPUnit\Framework\TestCase
      */
     public function isMinimumTimeBeforeShouldReturnTrueWhenNotBeforeClaimIsBeforeThanNow(): void
     {
-        $now = new DateTimeImmutable();
+        $now   = new DateTimeImmutable();
         $token = $this->createToken(
             null,
             new DataSet([RegisteredClaims::NOT_BEFORE => $now->modify('-100 seconds')], '')
@@ -512,7 +512,7 @@ final class PlainTest extends \PHPUnit\Framework\TestCase
      */
     public function isMinimumTimeBeforeShouldReturnTrueWhenNotBeforeClaimIsEqualsToNow(): void
     {
-        $now = new DateTimeImmutable();
+        $now   = new DateTimeImmutable();
         $token = $this->createToken(
             null,
             new DataSet([RegisteredClaims::NOT_BEFORE => $now], '')
@@ -532,7 +532,7 @@ final class PlainTest extends \PHPUnit\Framework\TestCase
      */
     public function isMinimumTimeBeforeShouldReturnFalseWhenNotBeforeClaimIsGreaterThanNow(): void
     {
-        $now = new DateTimeImmutable();
+        $now   = new DateTimeImmutable();
         $token = $this->createToken(
             null,
             new DataSet([RegisteredClaims::NOT_BEFORE => $now->modify('100 seconds')], '')

--- a/test/unit/Validation/Constraint/IssuedByTest.php
+++ b/test/unit/Validation/Constraint/IssuedByTest.php
@@ -77,7 +77,7 @@ final class IssuedByTest extends ConstraintTestCase
      */
     public function assertShouldNotRaiseExceptionWhenIssuerMatches(): void
     {
-        $token = $this->buildToken([RegisteredClaims::ISSUER => 'test.com']);
+        $token      = $this->buildToken([RegisteredClaims::ISSUER => 'test.com']);
         $constraint = new IssuedBy('test.com', 'test.net');
 
         self::assertNull($constraint->assert($token));

--- a/test/unit/Validation/Constraint/PermittedForTest.php
+++ b/test/unit/Validation/Constraint/PermittedForTest.php
@@ -77,7 +77,7 @@ final class PermittedForTest extends ConstraintTestCase
      */
     public function assertShouldNotRaiseExceptionWhenAudienceMatches(): void
     {
-        $token = $this->buildToken([RegisteredClaims::AUDIENCE => ['aa.com', 'test.com']]);
+        $token      = $this->buildToken([RegisteredClaims::AUDIENCE => ['aa.com', 'test.com']]);
         $constraint = new PermittedFor('test.com');
 
         self::assertNull($constraint->assert($token));

--- a/test/unit/Validation/Constraint/SignedWithTest.php
+++ b/test/unit/Validation/Constraint/SignedWithTest.php
@@ -36,7 +36,7 @@ final class SignedWithTest extends ConstraintTestCase
         $this->signer = $this->createMock(Signer::class);
         $this->signer->method('getAlgorithmId')->willReturn('RS256');
 
-        $this->key = new Signer\Key('123');
+        $this->key       = new Signer\Key('123');
         $this->signature = new Signature('1234', '5678');
     }
 

--- a/test/unit/Validation/Constraint/ValidAtTest.php
+++ b/test/unit/Validation/Constraint/ValidAtTest.php
@@ -167,7 +167,7 @@ final class ValidAtTest extends ConstraintTestCase
      */
     public function assertShouldNotRaiseExceptionWhenTokenDoesNotHaveTimeClaims(): void
     {
-        $token = $this->buildToken();
+        $token      = $this->buildToken();
         $constraint = new ValidAt($this->clock);
         self::assertNull($constraint->assert($token));
     }

--- a/test/unit/Validation/ValidatorTest.php
+++ b/test/unit/Validation/ValidatorTest.php
@@ -36,7 +36,7 @@ final class ValidatorTest extends \PHPUnit\Framework\TestCase
      */
     public function assertShouldRaiseExceptionWhenAtLeastOneConstraintFails(): void
     {
-        $failedConstraint = $this->createMock(Constraint::class);
+        $failedConstraint     = $this->createMock(Constraint::class);
         $successfulConstraint = $this->createMock(Constraint::class);
 
         $failedConstraint->expects($this->once())
@@ -77,7 +77,7 @@ final class ValidatorTest extends \PHPUnit\Framework\TestCase
      */
     public function validateShouldReturnFalseWhenAtLeastOneConstraintFails(): void
     {
-        $failedConstraint = $this->createMock(Constraint::class);
+        $failedConstraint     = $this->createMock(Constraint::class);
         $successfulConstraint = $this->createMock(Constraint::class);
 
         $failedConstraint->expects($this->once())


### PR DESCRIPTION
This is a PR for issue #198.
It includes the https://github.com/lcobucci/chimera-foundation/blob/b125eb9f07509ee977298d599655c2e1d391cf0e/phpcs.xml.dist cs rules.

They seem to break for the current code base (mostly the `=` alignment).
I can fix those as well if you like.