### PR TITLE
Fixed bug where audience claim could not be an array

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -74,14 +74,14 @@ class Builder
     /**
      * Configures the audience
      *
-     * @param string $audience
+     * @param string|array $audience
      * @param boolean $replicateAsHeader
      *
      * @return Builder
      */
     public function setAudience($audience, $replicateAsHeader = false)
     {
-        return $this->setRegisteredClaim('aud', (string) $audience, $replicateAsHeader);
+        return $this->setRegisteredClaim('aud', $audience, $replicateAsHeader);
     }
 
     /**

--- a/test/unit/BuilderTest.php
+++ b/test/unit/BuilderTest.php
@@ -96,6 +96,24 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
      * @covers Lcobucci\JWT\Builder::setAudience
      * @covers Lcobucci\JWT\Builder::setRegisteredClaim
      */
+    public function setAudienceCanChangeTheAudClaimWithArray()
+    {
+        $builder = $this->createBuilder();
+        $builder->setAudience(['test', 'another_test']);
+
+        $this->assertAttributeEquals(['alg' => 'none', 'typ' => 'JWT'], 'headers', $builder);
+        $this->assertAttributeEquals(['aud' => $this->defaultClaim], 'claims', $builder);
+    }
+
+    /**
+     * @test
+     *
+     * @uses Lcobucci\JWT\Builder::__construct
+     * @uses Lcobucci\JWT\Builder::set
+     *
+     * @covers Lcobucci\JWT\Builder::setAudience
+     * @covers Lcobucci\JWT\Builder::setRegisteredClaim
+     */
     public function setAudienceCanReplicateItemOnHeader()
     {
         $builder = $this->createBuilder();


### PR DESCRIPTION
According to https://tools.ietf.org/html/rfc7519#section-4.1.3 audience claim should be an array but MAY be a string