### PR TITLE
Don't require ext-openssl

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,7 @@
         "BSD-3-Clause"
     ],
     "require": {
-        "php": ">=5.5",
-        "ext-openssl": "*"
+        "php": ">=5.5"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.5",
@@ -29,7 +28,8 @@
         "mdanter/ecc": "~0.3.1"
     },
     "suggest":{
-        "mdanter/ecc": "Required to use Elliptic Curves based algorithms."
+        "mdanter/ecc": "Required to use Elliptic Curves based algorithms.",
+        "ext-openssl": "Required to use OpenSSL based signers such as RSA."
     },
     "autoload": {
         "psr-4": {

--- a/src/Signer/Rsa.php
+++ b/src/Signer/Rsa.php
@@ -17,6 +17,13 @@ use InvalidArgumentException;
  */
 abstract class Rsa extends BaseSigner
 {
+    public function __construct()
+    {
+        if (!extension_loaded('openssl')) {
+            throw new \RuntimeException('The OpenSSL extension is required to use RSA based signers.');
+        }
+    }
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
As it is not necessary when using Hmac signers. Already reflected by Rsa related tests that use the `@requires ext-openssl` annotation.