### PR TITLE
Fix travis link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Unstable Version](https://img.shields.io/packagist/vpre/lcobucci/jwt.svg?style=flat-square)](https://packagist.org/packages/lcobucci/jwt)
 
 ![Branch master](https://img.shields.io/badge/branch-master-brightgreen.svg?style=flat-square)
-[![Build Status](https://img.shields.io/travis/lcobucci/jwt/master.svg?style=flat-square)](http://travis-ci.org/#!/lcobucci/jwt)
+[![Build Status](https://img.shields.io/travis/lcobucci/jwt/master.svg?style=flat-square)](https://travis-ci.org/lcobucci/jwt)
 [![Scrutinizer Code Quality](https://img.shields.io/scrutinizer/g/lcobucci/jwt/master.svg?style=flat-square)](https://scrutinizer-ci.com/g/lcobucci/jwt/?branch=master)
 [![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/lcobucci/jwt/master.svg?style=flat-square)](https://scrutinizer-ci.com/g/lcobucci/jwt/?branch=master)
 [![SensioLabsInsight](https://insight.sensiolabs.com/projects/9c90ed7d-17de-4ba0-9ee0-3cf9c2f43f66/mini.png)](https://insight.sensiolabs.com/projects/9c90ed7d-17de-4ba0-9ee0-3cf9c2f43f66)
@@ -17,8 +17,8 @@ A simple library to work with JSON Web Token and JSON Web Signature based on the
 
 ## Installation
 
-Package is available on [Packagist](http://packagist.org/packages/lcobucci/jwt),
-you can install it using [Composer](http://getcomposer.org).
+Package is available on [Packagist](https://packagist.org/packages/lcobucci/jwt),
+you can install it using [Composer](https://getcomposer.org).
 
 ```shell
 composer require lcobucci/jwt


### PR DESCRIPTION
The previous link was broken (at least for me).

I also took the liberty of updating other links in the readme to https, where possible.