### PR TITLE
Remove assertion count manipulation

### DIFF
--- a/test/unit/Validation/Constraint/IdentifiedByTest.php
+++ b/test/unit/Validation/Constraint/IdentifiedByTest.php
@@ -45,6 +45,7 @@ final class IdentifiedByTest extends ConstraintTestCase
 
     /**
      * @test
+     * @doesNotPerformAssertions
      *
      * @covers \Lcobucci\JWT\Validation\Constraint\IdentifiedBy::__construct
      * @covers \Lcobucci\JWT\Validation\Constraint\IdentifiedBy::assert
@@ -60,6 +61,5 @@ final class IdentifiedByTest extends ConstraintTestCase
         $constraint = new IdentifiedBy('123456');
 
         $constraint->assert($token);
-        $this->addToAssertionCount(1);
     }
 }

--- a/test/unit/Validation/Constraint/IssuedByTest.php
+++ b/test/unit/Validation/Constraint/IssuedByTest.php
@@ -63,6 +63,7 @@ final class IssuedByTest extends ConstraintTestCase
 
     /**
      * @test
+     * @doesNotPerformAssertions
      *
      * @covers \Lcobucci\JWT\Validation\Constraint\IssuedBy::__construct
      * @covers \Lcobucci\JWT\Validation\Constraint\IssuedBy::assert
@@ -77,6 +78,5 @@ final class IssuedByTest extends ConstraintTestCase
         $constraint = new IssuedBy('test.com', 'test.net');
 
         $constraint->assert($token);
-        $this->addToAssertionCount(1);
     }
 }

--- a/test/unit/Validation/Constraint/PermittedForTest.php
+++ b/test/unit/Validation/Constraint/PermittedForTest.php
@@ -63,6 +63,7 @@ final class PermittedForTest extends ConstraintTestCase
 
     /**
      * @test
+     * @doesNotPerformAssertions
      *
      * @covers \Lcobucci\JWT\Validation\Constraint\PermittedFor::__construct
      * @covers \Lcobucci\JWT\Validation\Constraint\PermittedFor::assert
@@ -77,6 +78,5 @@ final class PermittedForTest extends ConstraintTestCase
         $constraint = new PermittedFor('test.com');
 
         $constraint->assert($token);
-        $this->addToAssertionCount(1);
     }
 }

--- a/test/unit/Validation/Constraint/RelatedToTest.php
+++ b/test/unit/Validation/Constraint/RelatedToTest.php
@@ -45,6 +45,7 @@ final class RelatedToTest extends ConstraintTestCase
 
     /**
      * @test
+     * @doesNotPerformAssertions
      *
      * @covers \Lcobucci\JWT\Validation\Constraint\RelatedTo::__construct
      * @covers \Lcobucci\JWT\Validation\Constraint\RelatedTo::assert
@@ -59,6 +60,5 @@ final class RelatedToTest extends ConstraintTestCase
         $constraint = new RelatedTo('user-auth');
 
         $constraint->assert($token);
-        $this->addToAssertionCount(1);
     }
 }

--- a/test/unit/Validation/Constraint/SignedWithTest.php
+++ b/test/unit/Validation/Constraint/SignedWithTest.php
@@ -128,6 +128,5 @@ final class SignedWithTest extends ConstraintTestCase
         $constraint = new SignedWith($this->signer, $this->key);
 
         $constraint->assert($token);
-        $this->addToAssertionCount(1);
     }
 }

--- a/test/unit/Validation/Constraint/ValidAtTest.php
+++ b/test/unit/Validation/Constraint/ValidAtTest.php
@@ -111,6 +111,7 @@ final class ValidAtTest extends ConstraintTestCase
 
     /**
      * @test
+     * @doesNotPerformAssertions
      *
      * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::__construct
      * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::assert
@@ -136,7 +137,6 @@ final class ValidAtTest extends ConstraintTestCase
         );
 
         $constraint->assert($token);
-        $this->addToAssertionCount(1);
 
         $token = $this->buildToken(
             [
@@ -147,11 +147,11 @@ final class ValidAtTest extends ConstraintTestCase
         );
 
         $constraint->assert($token);
-        $this->addToAssertionCount(1);
     }
 
     /**
      * @test
+     * @doesNotPerformAssertions
      *
      * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::__construct
      * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::assert
@@ -169,6 +169,5 @@ final class ValidAtTest extends ConstraintTestCase
         $constraint = new ValidAt($this->clock);
 
         $constraint->assert($token);
-        $this->addToAssertionCount(1);
     }
 }

--- a/test/unit/Validation/ValidatorTest.php
+++ b/test/unit/Validation/ValidatorTest.php
@@ -67,7 +67,6 @@ final class ValidatorTest extends TestCase
         $validator = new Validator();
 
         $validator->assert($this->token, $constraint);
-        $this->addToAssertionCount(1);
     }
 
     /**


### PR DESCRIPTION
Using `@doesNotPerformAssertions` is preferred since it doesn't rely on PHPUnit's internals.