### PR TITLE
Add leeway to ValidAt constraint

### DIFF
--- a/test/unit/Validation/Constraint/ValidAtTest.php
+++ b/test/unit/Validation/Constraint/ValidAtTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Lcobucci\JWT\Validation\Constraint;
 
+use DateInterval;
 use DateTimeImmutable;
 use Lcobucci\Clock\Clock;
 use Lcobucci\Clock\FrozenClock;
@@ -26,9 +27,26 @@ final class ValidAtTest extends ConstraintTestCase
     /**
      * @test
      *
+     * @expectedException \InvalidArgumentException
+     *
+     * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::__construct
+     * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::guardLeeway
+     */
+    public function constructShouldRaiseExceptionOnNegativeLeeway(): void
+    {
+        $leeway         = new DateInterval('PT30S');
+        $leeway->invert = 1;
+
+        new ValidAt($this->clock, $leeway);
+    }
+
+    /**
+     * @test
+     *
      * @expectedException \Lcobucci\JWT\Validation\ConstraintViolation
      *
      * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::__construct
+     * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::guardLeeway
      * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::assert
      * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::assertExpiration
      * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::assertIssueTime
@@ -58,6 +76,7 @@ final class ValidAtTest extends ConstraintTestCase
      * @expectedException \Lcobucci\JWT\Validation\ConstraintViolation
      *
      * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::__construct
+     * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::guardLeeway
      * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::assert
      * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::assertExpiration
      * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::assertIssueTime
@@ -87,6 +106,7 @@ final class ValidAtTest extends ConstraintTestCase
      * @expectedException \Lcobucci\JWT\Validation\ConstraintViolation
      *
      * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::__construct
+     * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::guardLeeway
      * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::assert
      * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::assertExpiration
      * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::assertIssueTime
@@ -114,6 +134,36 @@ final class ValidAtTest extends ConstraintTestCase
      * @doesNotPerformAssertions
      *
      * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::__construct
+     * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::guardLeeway
+     * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::assert
+     * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::assertExpiration
+     * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::assertIssueTime
+     * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::assertMinimumTime
+     *
+     * @uses \Lcobucci\JWT\Token\DataSet
+     * @uses \Lcobucci\JWT\Token\Plain
+     * @uses \Lcobucci\JWT\Token\Signature
+     */
+    public function assertShouldNotRaiseExceptionWhenLeewayIsUsed(): void
+    {
+        $now = $this->clock->now();
+
+        $claims = [
+            RegisteredClaims::ISSUED_AT => $now->modify('+5 seconds'),
+            RegisteredClaims::NOT_BEFORE => $now->modify('+5 seconds'),
+            RegisteredClaims::EXPIRATION_TIME => $now->modify('-5 seconds'),
+        ];
+
+        $constraint = new ValidAt($this->clock, new DateInterval('PT5S'));
+        $constraint->assert($this->buildToken($claims));
+    }
+
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     *
+     * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::__construct
+     * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::guardLeeway
      * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::assert
      * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::assertExpiration
      * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::assertIssueTime
@@ -154,6 +204,7 @@ final class ValidAtTest extends ConstraintTestCase
      * @doesNotPerformAssertions
      *
      * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::__construct
+     * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::guardLeeway
      * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::assert
      * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::assertExpiration
      * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt::assertIssueTime


### PR DESCRIPTION
To address clock skew issues.

More info:

- https://github.com/lcobucci/jwt/issues/191
- https://github.com/lcobucci/jwt/pull/248