### PR TITLE
Make audience argument variadic in builder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require-dev": {
         "infection/infection": "^0.12",
         "lcobucci/coding-standard": "^2.0",
-        "mikey179/vfsStream": "^1.6",
+        "mikey179/vfsstream": "^1.6",
         "phpbench/phpbench": "dev-master@dev",
         "phpmd/phpmd": "^2.5",
         "phpstan/phpstan": "^0.11",

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -11,9 +11,9 @@ use Lcobucci\JWT\Token\Plain;
 interface Builder
 {
     /**
-     * Appends a new audience
+     * Appends new items to audience
      */
-    public function permittedFor(string $audience): Builder;
+    public function permittedFor(string ...$audiences): Builder;
 
     /**
      * Configures the expiration time

--- a/src/Token/Builder.php
+++ b/src/Token/Builder.php
@@ -9,8 +9,10 @@ use Lcobucci\Jose\Parsing;
 use Lcobucci\JWT\Builder as BuilderInterface;
 use Lcobucci\JWT\Signer;
 use Lcobucci\JWT\Signer\Key;
+use function array_diff;
 use function array_intersect;
 use function array_keys;
+use function array_merge;
 use function in_array;
 
 final class Builder implements BuilderInterface
@@ -38,15 +40,12 @@ final class Builder implements BuilderInterface
     /**
      * {@inheritdoc}
      */
-    public function permittedFor(string $audience): BuilderInterface
+    public function permittedFor(string ...$audiences): BuilderInterface
     {
-        $audiences = $this->claims[RegisteredClaims::AUDIENCE] ?? [];
+        $configured = $this->claims[RegisteredClaims::AUDIENCE] ?? [];
+        $toAppend   = array_diff($audiences, $configured);
 
-        if (! in_array($audience, $audiences, true)) {
-            $audiences[] = $audience;
-        }
-
-        return $this->setClaim(RegisteredClaims::AUDIENCE, $audiences);
+        return $this->setClaim(RegisteredClaims::AUDIENCE, array_merge($configured, $toAppend));
     }
 
     /**

--- a/test/unit/Token/BuilderTest.php
+++ b/test/unit/Token/BuilderTest.php
@@ -138,7 +138,7 @@ final class BuilderTest extends TestCase
     public function audienceShouldBeFormattedAsArrayWhenMultipleValuesAreUsed(): void
     {
         $headers = ['typ' => 'JWT', 'alg' => 'RS256'];
-        $claims  = [RegisteredClaims::AUDIENCE => ['test1', 'test2']];
+        $claims  = [RegisteredClaims::AUDIENCE => ['test1', 'test2', 'test3']];
 
         $this->signer->method('sign')->willReturn('testing');
 
@@ -154,8 +154,7 @@ final class BuilderTest extends TestCase
 
         $builder = new Builder($this->encoder);
 
-        $builder->permittedFor('test1')
-                ->permittedFor('test2')
+        $builder->permittedFor('test1', 'test2', 'test3')
                 ->permittedFor('test2') // should not be added since it's duplicated
                 ->getToken($this->signer, new Key('123'));
     }


### PR DESCRIPTION
As discussed with @samjudge on #291 we can make things a bit easier for end-users here.

This change enables people to use such method in the following ways:

```php
$builder->permittedFor('foo'); // single item, original design
$builder->permittedFor('foo', 'bar', 'baz'); // multiple items as arguments
$builder->permittedFor(...['foo', 'bar', 'baz']); // multiple items as expanded array
```