### PR TITLE
Fix method name to match interface in v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $token = (new Builder())->issuedBy('http://example.com') // Configures the issue
                         ->issuedAt($time) // Configures the time that the token was issue (iat claim)
                         ->canOnlyBeUsedAfter($time + 60) // Configures the time that the token can be used (nbf claim)
                         ->expiresAt($time + 3600) // Configures the expiration time of the token (exp claim)
-                        ->with('uid', 1) // Configures a new claim, called "uid"
+                        ->withClaim('uid', 1) // Configures a new claim, called "uid"
                         ->getToken(); // Retrieves the generated token
 
 
@@ -156,7 +156,7 @@ $token = (new Builder())->issuedBy('http://example.com') // Configures the issue
                         ->issuedAt($time) // Configures the time that the token was issue (iat claim)
                         ->canOnlyBeUsedAfter($time + 60) // Configures the time that the token can be used (nbf claim)
                         ->expiresAt($time + 3600) // Configures the expiration time of the token (exp claim)
-                        ->with('uid', 1) // Configures a new claim, called "uid"
+                        ->withClaim('uid', 1) // Configures a new claim, called "uid"
                         ->getToken($signer, new Key('testing')); // Retrieves the generated token
 
 
@@ -183,7 +183,7 @@ $token = (new Builder())->issuedBy('http://example.com') // Configures the issue
                         ->issuedAt($time) // Configures the time that the token was issue (iat claim)
                         ->canOnlyBeUsedAfter($time + 60) // Configures the time that the token can be used (nbf claim)
                         ->expiresAt($time + 3600) // Configures the expiration time of the token (exp claim)
-                        ->with('uid', 1) // Configures a new claim, called "uid"
+                        ->withClaim('uid', 1) // Configures a new claim, called "uid"
                         ->getToken($signer,  $privateKey); // Retrieves the generated token
 
 $publicKey = new Key('file://{path to your public key}');

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "squizlabs/php_codesniffer": "~2.3",
         "phpmd/phpmd": "~2.2",
         "phpunit/php-invoker": "~1.1",
-        "mikey179/vfsStream": "~1.5"
+        "mikey179/vfsstream": "~1.5"
     },
     "autoload": {
         "psr-4": {

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -287,7 +287,7 @@ class Builder
      */
     protected function setRegisteredClaim($name, $value, $replicate)
     {
-        $this->with($name, $value);
+        $this->withClaim($name, $value);
 
         if ($replicate) {
             $this->headers[$name] = $this->claims[$name];
@@ -330,12 +330,28 @@ class Builder
     /**
      * Configures a claim item
      *
+     * @deprecated This method has been wrongly added and doesn't exist on v4
+     * @see Builder::withClaim()
+     *
      * @param string $name
      * @param mixed $value
      *
      * @return Builder
      */
     public function with($name, $value)
+    {
+        return $this->withClaim($name, $value);
+    }
+
+    /**
+     * Configures a claim item
+     *
+     * @param string $name
+     * @param mixed $value
+     *
+     * @return Builder
+     */
+    public function withClaim($name, $value)
     {
         $this->claims[(string) $name] = $this->claimFactory->create($name, $value);
 
@@ -346,7 +362,7 @@ class Builder
      * Configures a claim item
      *
      * @deprecated This method will be removed on v4
-     * @see Builder::with()
+     * @see Builder::withClaim()
      *
      * @param string $name
      * @param mixed $value
@@ -355,7 +371,7 @@ class Builder
      */
     public function set($name, $value)
     {
-        return $this->with($name, $value);
+        return $this->withClaim($name, $value);
     }
 
     /**

--- a/test/unit/BuilderTest.php
+++ b/test/unit/BuilderTest.php
@@ -73,7 +73,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses Lcobucci\JWT\Builder::__construct
-     * @uses Lcobucci\JWT\Builder::with
+     * @uses Lcobucci\JWT\Builder::withClaim
      *
      * @covers Lcobucci\JWT\Builder::canOnlyBeUsedBy
      * @covers Lcobucci\JWT\Builder::setRegisteredClaim
@@ -91,7 +91,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses Lcobucci\JWT\Builder::__construct
-     * @uses Lcobucci\JWT\Builder::with
+     * @uses Lcobucci\JWT\Builder::withClaim
      *
      * @covers Lcobucci\JWT\Builder::canOnlyBeUsedBy
      * @covers Lcobucci\JWT\Builder::setRegisteredClaim
@@ -114,7 +114,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses Lcobucci\JWT\Builder::__construct
-     * @uses Lcobucci\JWT\Builder::with
+     * @uses Lcobucci\JWT\Builder::withClaim
      *
      * @covers Lcobucci\JWT\Builder::canOnlyBeUsedBy
      * @covers Lcobucci\JWT\Builder::setRegisteredClaim
@@ -130,7 +130,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses Lcobucci\JWT\Builder::__construct
-     * @uses Lcobucci\JWT\Builder::with
+     * @uses Lcobucci\JWT\Builder::withClaim
      *
      * @covers Lcobucci\JWT\Builder::expiresAt
      * @covers Lcobucci\JWT\Builder::setRegisteredClaim
@@ -148,7 +148,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses Lcobucci\JWT\Builder::__construct
-     * @uses Lcobucci\JWT\Builder::with
+     * @uses Lcobucci\JWT\Builder::withClaim
      *
      * @covers Lcobucci\JWT\Builder::expiresAt
      * @covers Lcobucci\JWT\Builder::setRegisteredClaim
@@ -171,7 +171,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses Lcobucci\JWT\Builder::__construct
-     * @uses Lcobucci\JWT\Builder::with
+     * @uses Lcobucci\JWT\Builder::withClaim
      *
      * @covers Lcobucci\JWT\Builder::expiresAt
      * @covers Lcobucci\JWT\Builder::setRegisteredClaim
@@ -187,7 +187,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses Lcobucci\JWT\Builder::__construct
-     * @uses Lcobucci\JWT\Builder::with
+     * @uses Lcobucci\JWT\Builder::withClaim
      *
      * @covers Lcobucci\JWT\Builder::identifiedBy
      * @covers Lcobucci\JWT\Builder::setRegisteredClaim
@@ -205,7 +205,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses Lcobucci\JWT\Builder::__construct
-     * @uses Lcobucci\JWT\Builder::with
+     * @uses Lcobucci\JWT\Builder::withClaim
      *
      * @covers Lcobucci\JWT\Builder::identifiedBy
      * @covers Lcobucci\JWT\Builder::setRegisteredClaim
@@ -228,7 +228,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses Lcobucci\JWT\Builder::__construct
-     * @uses Lcobucci\JWT\Builder::with
+     * @uses Lcobucci\JWT\Builder::withClaim
      *
      * @covers Lcobucci\JWT\Builder::identifiedBy
      * @covers Lcobucci\JWT\Builder::setRegisteredClaim
@@ -244,7 +244,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses Lcobucci\JWT\Builder::__construct
-     * @uses Lcobucci\JWT\Builder::with
+     * @uses Lcobucci\JWT\Builder::withClaim
      *
      * @covers Lcobucci\JWT\Builder::issuedAt
      * @covers Lcobucci\JWT\Builder::setRegisteredClaim
@@ -262,7 +262,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses Lcobucci\JWT\Builder::__construct
-     * @uses Lcobucci\JWT\Builder::with
+     * @uses Lcobucci\JWT\Builder::withClaim
      *
      * @covers Lcobucci\JWT\Builder::issuedAt
      * @covers Lcobucci\JWT\Builder::setRegisteredClaim
@@ -285,7 +285,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses Lcobucci\JWT\Builder::__construct
-     * @uses Lcobucci\JWT\Builder::with
+     * @uses Lcobucci\JWT\Builder::withClaim
      *
      * @covers Lcobucci\JWT\Builder::issuedAt
      * @covers Lcobucci\JWT\Builder::setRegisteredClaim
@@ -301,7 +301,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses Lcobucci\JWT\Builder::__construct
-     * @uses Lcobucci\JWT\Builder::with
+     * @uses Lcobucci\JWT\Builder::withClaim
      *
      * @covers Lcobucci\JWT\Builder::issuedBy
      * @covers Lcobucci\JWT\Builder::setRegisteredClaim
@@ -319,7 +319,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses Lcobucci\JWT\Builder::__construct
-     * @uses Lcobucci\JWT\Builder::with
+     * @uses Lcobucci\JWT\Builder::withClaim
      *
      * @covers Lcobucci\JWT\Builder::issuedBy
      * @covers Lcobucci\JWT\Builder::setRegisteredClaim
@@ -342,7 +342,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses Lcobucci\JWT\Builder::__construct
-     * @uses Lcobucci\JWT\Builder::with
+     * @uses Lcobucci\JWT\Builder::withClaim
      *
      * @covers Lcobucci\JWT\Builder::issuedBy
      * @covers Lcobucci\JWT\Builder::setRegisteredClaim
@@ -358,7 +358,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses Lcobucci\JWT\Builder::__construct
-     * @uses Lcobucci\JWT\Builder::with
+     * @uses Lcobucci\JWT\Builder::withClaim
      *
      * @covers Lcobucci\JWT\Builder::canOnlyBeUsedAfter
      * @covers Lcobucci\JWT\Builder::setRegisteredClaim
@@ -376,7 +376,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses Lcobucci\JWT\Builder::__construct
-     * @uses Lcobucci\JWT\Builder::with
+     * @uses Lcobucci\JWT\Builder::withClaim
      *
      * @covers Lcobucci\JWT\Builder::canOnlyBeUsedAfter
      * @covers Lcobucci\JWT\Builder::setRegisteredClaim
@@ -399,7 +399,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses Lcobucci\JWT\Builder::__construct
-     * @uses Lcobucci\JWT\Builder::with
+     * @uses Lcobucci\JWT\Builder::withClaim
      *
      * @covers Lcobucci\JWT\Builder::canOnlyBeUsedAfter
      * @covers Lcobucci\JWT\Builder::setRegisteredClaim
@@ -415,7 +415,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses Lcobucci\JWT\Builder::__construct
-     * @uses Lcobucci\JWT\Builder::with
+     * @uses Lcobucci\JWT\Builder::withClaim
      *
      * @covers Lcobucci\JWT\Builder::relatedTo
      * @covers Lcobucci\JWT\Builder::setRegisteredClaim
@@ -433,7 +433,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses Lcobucci\JWT\Builder::__construct
-     * @uses Lcobucci\JWT\Builder::with
+     * @uses Lcobucci\JWT\Builder::withClaim
      *
      * @covers Lcobucci\JWT\Builder::relatedTo
      * @covers Lcobucci\JWT\Builder::setRegisteredClaim
@@ -456,7 +456,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses Lcobucci\JWT\Builder::__construct
-     * @uses Lcobucci\JWT\Builder::with
+     * @uses Lcobucci\JWT\Builder::withClaim
      *
      * @covers Lcobucci\JWT\Builder::relatedTo
      * @covers Lcobucci\JWT\Builder::setRegisteredClaim
@@ -473,12 +473,12 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      *
      * @uses Lcobucci\JWT\Builder::__construct
      *
-     * @covers Lcobucci\JWT\Builder::with
+     * @covers Lcobucci\JWT\Builder::withClaim
      */
-    public function withMustConfigureTheGivenClaim()
+    public function withClaimMustConfigureTheGivenClaim()
     {
         $builder = $this->createBuilder();
-        $builder->with('userId', 2);
+        $builder->withClaim('userId', 2);
 
         $this->assertAttributeEquals(['userId' => $this->defaultClaim], 'claims', $builder);
     }
@@ -488,13 +488,13 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      *
      * @uses Lcobucci\JWT\Builder::__construct
      *
-     * @covers Lcobucci\JWT\Builder::with
+     * @covers Lcobucci\JWT\Builder::withClaim
      */
-    public function withMustKeepAFluentInterface()
+    public function withClaimMustKeepAFluentInterface()
     {
         $builder = $this->createBuilder();
 
-        $this->assertSame($builder, $builder->with('userId', 2));
+        $this->assertSame($builder, $builder->withClaim('userId', 2));
     }
 
     /**
@@ -600,7 +600,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      *
      * @uses Lcobucci\JWT\Builder::__construct
-     * @uses Lcobucci\JWT\Builder::with
+     * @uses Lcobucci\JWT\Builder::withClaim
      * @uses Lcobucci\JWT\Token
      *
      * @covers Lcobucci\JWT\Builder::getToken
@@ -622,7 +622,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
                       ->withConsecutive(['1'], ['2'], [$signature])
                       ->willReturnOnConsecutiveCalls('1', '2', '3');
 
-        $builder = $this->createBuilder()->with('test', 123);
+        $builder = $this->createBuilder()->withClaim('test', 123);
         $token = $builder->getToken($signer, new Key('testing'));
 
         $this->assertAttributeEquals(['1', '2', '3'], 'payload', $token);


### PR DESCRIPTION
As pointed out by @MasterOdin this was incorrect in v3.3.