### PR TITLE
Added multiple audiences support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ use Lcobucci\JWT\ValidationData;
 $data = new ValidationData(); // It will use the current time to validate (iat, nbf and exp)
 $data->setIssuer('http://example.com');
 $data->setAudience('http://example.org');
+$data->setAudiences(['http://example.org', 'http://anotherexample.org']); // Or with multiple audiences
 $data->setId('4f1g23a12aa');
 
 var_dump($token->validate($data)); // false, because token cannot be used before now() + 60

--- a/src/ValidationData.php
+++ b/src/ValidationData.php
@@ -80,6 +80,16 @@ class ValidationData
     }
 
     /**
+     * Configures the audiences
+     *
+     * @param string[] $audiences
+     */
+    public function setAudiences($audiences)
+    {
+        $this->items['aud'] = array_map('strval', $audiences);
+    }
+
+    /**
      * Configures the subject
      *
      * @param string $subject

--- a/test/unit/ValidationDataTest.php
+++ b/test/unit/ValidationDataTest.php
@@ -106,6 +106,26 @@ class ValidationDataTest extends \PHPUnit\Framework\TestCase
      * @uses Lcobucci\JWT\ValidationData::__construct
      * @uses Lcobucci\JWT\ValidationData::setCurrentTime
      *
+     * @covers Lcobucci\JWT\ValidationData::setAudience
+     */
+    public function setAudiencesShouldChangeTheAudience()
+    {
+        $aud = ['::aud-1::', '::aud-2::'];
+        $expected = $this->createExpectedData(null, null, null, $aud);
+        $data = new ValidationData(1);
+        $data->setAudiences($aud);
+
+        $this->assertAttributeSame($expected, 'items', $data);
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider claimValues
+     *
+     * @uses Lcobucci\JWT\ValidationData::__construct
+     * @uses Lcobucci\JWT\ValidationData::setCurrentTime
+     *
      * @covers Lcobucci\JWT\ValidationData::setSubject
      */
     public function setSubjectShouldChangeTheSubject($sub)
@@ -257,10 +277,14 @@ class ValidationDataTest extends \PHPUnit\Framework\TestCase
         $nbf = null,
         $exp = null
     ) {
+        if($aud !== null && !is_array($aud)) {
+            $aud = (string) $aud;
+        }
+
         return [
             'jti' => $id !== null ? (string) $id : null,
             'iss' => $iss !== null ? (string) $iss : null,
-            'aud' => $aud !== null ? (string) $aud : null,
+            'aud' => $aud !== null ? $aud : null,
             'sub' => $sub !== null ? (string) $sub : null,
             'iat' => $iat,
             'nbf' => $nbf !== null ? $nbf: $iat,


### PR DESCRIPTION
Version 3.3 does not support multiple audiences for validating a token as RFC says (https://tools.ietf.org/html/rfc7519#section-4.1.3), it should support more than one.
I noticed new version will support multiple audiences, but meanwhile, here it is a PR fixing it on branch 3.4.
I created a new method `setAudiences()` in order to not break current API.