### PR TITLE
Remove inline signaling from Key

### DIFF
--- a/src/Signer/Key.php
+++ b/src/Signer/Key.php
@@ -8,8 +8,6 @@ use SplFileObject;
 use Throwable;
 use function assert;
 use function is_string;
-use function strpos;
-use function substr;
 
 final class Key
 {
@@ -25,36 +23,24 @@ final class Key
 
     public function __construct(string $content, string $passphrase = '')
     {
-        $this->setContent($content);
+        $this->content    = $content;
         $this->passphrase = $passphrase;
     }
 
     /**
      * @throws InvalidArgumentException
      */
-    private function setContent(string $content): void
-    {
-        if (strpos($content, 'file://') === 0) {
-            $content = $this->readFile($content);
-        }
-
-        $this->content = $content;
-    }
-
-    /**
-     * @throws InvalidArgumentException
-     */
-    private function readFile(string $content): string
+    public static function fromFile(string $filename, string $passphrase = ''): self
     {
         try {
-            $file    = new SplFileObject(substr($content, 7));
+            $file    = new SplFileObject($filename);
             $content = $file->fread($file->getSize());
             assert(is_string($content));
-
-            return $content;
         } catch (Throwable $exception) {
             throw new InvalidArgumentException('You must provide a valid key file', $exception->getCode(), $exception);
         }
+
+        return new self($content, $passphrase);
     }
 
     public function getContent(): string

--- a/test/unit/Signer/KeyTest.php
+++ b/test/unit/Signer/KeyTest.php
@@ -25,15 +25,14 @@ final class KeyTest extends TestCase
      * @test
      *
      * @covers \Lcobucci\JWT\Signer\Key::__construct
-     * @covers \Lcobucci\JWT\Signer\Key::setContent
-     * @covers \Lcobucci\JWT\Signer\Key::readFile
+     * @covers \Lcobucci\JWT\Signer\Key::fromFile
      */
     public function constructShouldRaiseExceptionWhenFileDoesNotExists(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('You must provide a valid key file');
 
-        new Key('file://' . vfsStream::url('root/test2.pem'));
+        Key::fromFile(vfsStream::url('root/test2.pem'));
     }
 
     /**
@@ -55,13 +54,12 @@ final class KeyTest extends TestCase
      * @test
      *
      * @covers \Lcobucci\JWT\Signer\Key::__construct
-     * @covers \Lcobucci\JWT\Signer\Key::setContent
-     * @covers \Lcobucci\JWT\Signer\Key::readFile
+     * @covers \Lcobucci\JWT\Signer\Key::fromFile
      * @covers \Lcobucci\JWT\Signer\Key::getContent
      */
-    public function getContentShouldReturnFileContentsWhenFilePathHasBeenPassed(): void
+    public function getContentShouldReturnFileContentsWhenReadFromFile(): void
     {
-        $key = new Key('file://' . vfsStream::url('root/test.pem'));
+        $key = Key::fromFile(vfsStream::url('root/test.pem'));
 
         self::assertSame('testing', $key->getContent());
     }


### PR DESCRIPTION
Currently `Lcobucci\JWT\Signer\Key` utilizes a magic sentinel `'file://'` to decide whether or not to read key content from a file.

Inline signalling like this can be troublesome and more than a little dangerous at times. It can also potentially (however unlikely) lead to _accidentally_ attempting to read from a file.

As an alternative I would like to propose perhaps a static secondary constructor "fromFile" where a user could _specifically_ request a file's contents.

It's not a large change, but adds a lot in the way of safety. As v4 final is not yet tagged I hope this breaking change isn't asking too much.