### PR TITLE
Validator: raise exception when no constraint is given

### DIFF
--- a/docs/validating-tokens.md
+++ b/docs/validating-tokens.md
@@ -64,3 +64,5 @@ This library provides the following constraints:
 * `Lcobucci\JWT\Validation\Constraint\ValidAt`: verifies the claims `iat`, `nbf`, and `exp` (supports leeway configuration)
 
 You may also create your [own validation constraints](extending-the-library.md#validation-constraints).
+
+You must provide at least one constraint, otherwise `\Lcobucci\JWT\Validation\NoConstraintsGiven` exception will be thrown.

--- a/docs/validating-tokens.md
+++ b/docs/validating-tokens.md
@@ -8,6 +8,9 @@ To validate a token you must create a new validator (easier when using the [conf
 
 ## Using `Lcobucci\JWT\Validator#assert()`
 
+!!! Warning
+    You **MUST** provide at least one constraint, otherwise `\Lcobucci\JWT\Validation\NoConstraintsGiven` exception will be thrown.
+
 This method goes through every single constraint in the set, groups all the violations, and throws an exception with the grouped violations:
 
 ```php
@@ -32,6 +35,9 @@ try {
 ```
 
 ## Using `Lcobucci\JWT\Validator#validate()`
+
+!!! Warning
+    You **MUST** provide at least one constraint, otherwise `\Lcobucci\JWT\Validation\NoConstraintsGiven` exception will be thrown.
 
 The difference here is that we'll always a get a `boolean` result and stop in the very first violation:
 
@@ -64,5 +70,3 @@ This library provides the following constraints:
 * `Lcobucci\JWT\Validation\Constraint\ValidAt`: verifies the claims `iat`, `nbf`, and `exp` (supports leeway configuration)
 
 You may also create your [own validation constraints](extending-the-library.md#validation-constraints).
-
-You must provide at least one constraint, otherwise `\Lcobucci\JWT\Validation\NoConstraintsGiven` exception will be thrown.

--- a/src/Validation/NoConstraintsGiven.php
+++ b/src/Validation/NoConstraintsGiven.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace Lcobucci\JWT\Validation;
+
+use Lcobucci\JWT\Exception;
+
+final class NoConstraintsGiven extends Exception
+{
+}

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -12,6 +12,10 @@ final class Validator implements \Lcobucci\JWT\Validator
      */
     public function assert(Token $token, Constraint ...$constraints): void
     {
+        if ($constraints === []) {
+            throw new NoConstraintsGiven('No constraint given.');
+        }
+
         $violations = [];
 
         foreach ($constraints as $constraint) {
@@ -40,6 +44,10 @@ final class Validator implements \Lcobucci\JWT\Validator
 
     public function validate(Token $token, Constraint ...$constraints): bool
     {
+        if ($constraints === []) {
+            throw new NoConstraintsGiven('No constraint given.');
+        }
+
         try {
             foreach ($constraints as $constraint) {
                 $constraint->assert($token);

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -5,13 +5,18 @@ namespace Lcobucci\JWT;
 
 use Lcobucci\JWT\Validation\Constraint;
 use Lcobucci\JWT\Validation\InvalidToken;
+use Lcobucci\JWT\Validation\NoConstraintsGiven;
 
 interface Validator
 {
     /**
      * @throws InvalidToken
+     * @throws NoConstraintsGiven
      */
     public function assert(Token $token, Constraint ...$constraints): void;
 
+    /**
+     * @throws NoConstraintsGiven
+     */
     public function validate(Token $token, Constraint ...$constraints): bool;
 }

--- a/test/unit/Validation/ValidatorTest.php
+++ b/test/unit/Validation/ValidatorTest.php
@@ -26,6 +26,20 @@ final class ValidatorTest extends TestCase
      * @test
      *
      * @covers \Lcobucci\JWT\Validation\Validator::assert
+     */
+    public function assertShouldRaiseExceptionWhenNoConstraintIsGiven(): void
+    {
+        $validator = new Validator();
+
+        $this->expectException(NoConstraintsGiven::class);
+
+        $validator->assert($this->token, ...[]);
+    }
+
+    /**
+     * @test
+     *
+     * @covers \Lcobucci\JWT\Validation\Validator::assert
      * @covers \Lcobucci\JWT\Validation\Validator::checkConstraint
      *
      * @uses \Lcobucci\JWT\Validation\InvalidToken
@@ -69,6 +83,20 @@ final class ValidatorTest extends TestCase
 
         $validator->assert($this->token, $constraint);
         $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @test
+     *
+     * @covers \Lcobucci\JWT\Validation\Validator::validate
+     */
+    public function validateShouldRaiseExceptionWhenNoConstraintIsGiven(): void
+    {
+        $validator = new Validator();
+
+        $this->expectException(NoConstraintsGiven::class);
+
+        $validator->validate($this->token, ...[]);
     }
 
     /**


### PR DESCRIPTION
Hi, today I expected a token to fail, but the assertion made as described in https://lcobucci-jwt.readthedocs.io/en/latest/validating-tokens/ didn't raise any error.
After a while I found no build-in Constraint is provided (and that's ok for me), but also no error is raised when this happen.

I'm scared that many users would fall into my mistake, a pretty dangerous mistake!