### PR TITLE
add toString method

### DIFF
--- a/docs/issuing-tokens.md
+++ b/docs/issuing-tokens.md
@@ -54,5 +54,6 @@ $token->claims(); // Retrieves the token claims
 echo $token->headers()->get('foo'); // will print "bar"
 echo $token->claims()->get('iss'); // will print "http://example.com"
 echo $token->claims()->get('uid'); // will print "1"
-echo $token; // The string representation of the object is a JWT string
+
+echo $token->toString(); // The string representation of the object is a JWT string
 ```

--- a/src/Token.php
+++ b/src/Token.php
@@ -51,5 +51,5 @@ interface Token
     /**
      * Returns an encoded representation of the token
      */
-    public function __toString(): string;
+    public function toString(): string;
 }

--- a/src/Token/DataSet.php
+++ b/src/Token/DataSet.php
@@ -49,7 +49,7 @@ final class DataSet
         return $this->data;
     }
 
-    public function __toString(): string
+    public function toString(): string
     {
         return $this->encoded;
     }

--- a/src/Token/Plain.php
+++ b/src/Token/Plain.php
@@ -5,7 +5,6 @@ namespace Lcobucci\JWT\Token;
 
 use DateTimeInterface;
 use Lcobucci\JWT\Token as TokenInterface;
-use function implode;
 use function in_array;
 
 final class Plain implements TokenInterface
@@ -132,9 +131,8 @@ final class Plain implements TokenInterface
      */
     public function toString(): string
     {
-        return implode(
-            '.',
-            [$this->headers->toString(), $this->claims->toString(), $this->signature->toString()]
-        );
+        return $this->headers->toString() . '.'
+             . $this->claims->toString() . '.'
+             . $this->signature->toString();
     }
 }

--- a/src/Token/Plain.php
+++ b/src/Token/Plain.php
@@ -64,7 +64,7 @@ final class Plain implements TokenInterface
      */
     public function payload(): string
     {
-        return $this->headers . '.' . $this->claims;
+        return $this->headers->toString() . '.' . $this->claims->toString();
     }
 
     /**
@@ -130,11 +130,11 @@ final class Plain implements TokenInterface
     /**
      * {@inheritdoc}
      */
-    public function __toString(): string
+    public function toString(): string
     {
         return implode(
             '.',
-            [$this->headers, $this->claims, $this->signature]
+            [$this->headers->toString(), $this->claims->toString(), $this->signature->toString()]
         );
     }
 }

--- a/src/Token/Signature.php
+++ b/src/Token/Signature.php
@@ -34,7 +34,7 @@ final class Signature
     /**
      * Returns the encoded version of the signature
      */
-    public function __toString(): string
+    public function toString(): string
     {
         return $this->encoded;
     }

--- a/test/functional/ES512TokenTest.php
+++ b/test/functional/ES512TokenTest.php
@@ -147,7 +147,7 @@ class ES512TokenTest extends TestCase
     public function parserCanReadAToken(Token $generated): void
     {
         /** @var Token\Plain $read */
-        $read = $this->config->getParser()->parse((string) $generated);
+        $read = $this->config->getParser()->parse($generated->toString());
 
         self::assertEquals($generated, $read);
         self::assertEquals('testing', $read->claims()->get('user')['name']);

--- a/test/functional/EcdsaTokenTest.php
+++ b/test/functional/EcdsaTokenTest.php
@@ -148,7 +148,7 @@ class EcdsaTokenTest extends TestCase
     public function parserCanReadAToken(Token $generated): void
     {
         /** @var Token\Plain $read */
-        $read = $this->config->getParser()->parse((string) $generated);
+        $read = $this->config->getParser()->parse($generated->toString());
 
         self::assertEquals($generated, $read);
         self::assertEquals('testing', $read->claims()->get('user')['name']);

--- a/test/functional/HmacTokenTest.php
+++ b/test/functional/HmacTokenTest.php
@@ -74,7 +74,7 @@ class HmacTokenTest extends TestCase
     public function parserCanReadAToken(Token $generated): void
     {
         /** @var Token\Plain $read */
-        $read = $this->config->getParser()->parse((string) $generated);
+        $read = $this->config->getParser()->parse($generated->toString());
 
         self::assertEquals($generated, $read);
         self::assertEquals('testing', $read->claims()->get('user')['name']);

--- a/test/functional/RsaTokenTest.php
+++ b/test/functional/RsaTokenTest.php
@@ -136,7 +136,7 @@ class RsaTokenTest extends TestCase
     public function parserCanReadAToken(Token $generated): void
     {
         /** @var Token\Plain $read */
-        $read = $this->config->getParser()->parse((string) $generated);
+        $read = $this->config->getParser()->parse($generated->toString());
 
         self::assertEquals($generated, $read);
         self::assertEquals('testing', $read->claims()->get('user')['name']);

--- a/test/functional/UnsignedTokenTest.php
+++ b/test/functional/UnsignedTokenTest.php
@@ -83,7 +83,7 @@ class UnsignedTokenTest extends TestCase
     public function parserCanReadAToken(Token $generated): void
     {
         /** @var Token\Plain $read */
-        $read = $this->config->getParser()->parse((string) $generated);
+        $read = $this->config->getParser()->parse($generated->toString());
 
         self::assertEquals($generated, $read);
         self::assertEquals('testing', $read->claims()->get('user')['name']);

--- a/test/unit/Token/BuilderTest.php
+++ b/test/unit/Token/BuilderTest.php
@@ -224,6 +224,6 @@ final class BuilderTest extends TestCase
         self::assertSame('https://issuer.com', $token->claims()->get(RegisteredClaims::ISSUER));
         self::assertSame('subject', $token->claims()->get(RegisteredClaims::SUBJECT));
         self::assertSame(['test1', 'test2'], $token->claims()->get(RegisteredClaims::AUDIENCE));
-        self::assertSame('3', (string) $token->signature());
+        self::assertSame('3', $token->signature()->toString());
     }
 }

--- a/test/unit/Token/DataSetTest.php
+++ b/test/unit/Token/DataSetTest.php
@@ -19,7 +19,7 @@ final class DataSetTest extends TestCase
     {
         $set = new DataSet(['one' => 1], 'one=1');
 
-        self::assertEquals(1, $set->get('one'));
+        self::assertSame(1, $set->get('one'));
     }
 
     /**
@@ -34,7 +34,7 @@ final class DataSetTest extends TestCase
     {
         $set = new DataSet(['one' => 1], 'one=1');
 
-        self::assertEquals(2, $set->get('two', 2));
+        self::assertSame(2, $set->get('two', 2));
     }
 
     /**
@@ -89,19 +89,19 @@ final class DataSetTest extends TestCase
         $items = ['one' => 1, 'two' => 2];
         $set   = new DataSet($items, 'one=1');
 
-        self::assertEquals($items, $set->all());
+        self::assertSame($items, $set->all());
     }
 
     /**
      * @test
      *
      * @covers \Lcobucci\JWT\Token\DataSet::__construct
-     * @covers \Lcobucci\JWT\Token\DataSet::__toString
+     * @covers \Lcobucci\JWT\Token\DataSet::toString
      */
     public function toStringShouldReturnTheEncodedData(): void
     {
         $set = new DataSet(['one' => 1], 'one=1');
 
-        self::assertEquals('one=1', (string) $set);
+        self::assertSame('one=1', $set->toString());
     }
 }

--- a/test/unit/Token/PlainTest.php
+++ b/test/unit/Token/PlainTest.php
@@ -78,7 +78,7 @@ final class PlainTest extends TestCase
     {
         $token = $this->createToken();
 
-        self::assertEquals('headers.claims', $token->payload());
+        self::assertSame('headers.claims', $token->payload());
     }
 
     /**
@@ -569,7 +569,7 @@ final class PlainTest extends TestCase
     /**
      * @test
      *
-     * @covers \Lcobucci\JWT\Token\Plain::__toString
+     * @covers \Lcobucci\JWT\Token\Plain::toString
      *
      * @uses \Lcobucci\JWT\Token\Plain::__construct
      * @uses \Lcobucci\JWT\Token\Plain::payload
@@ -580,13 +580,13 @@ final class PlainTest extends TestCase
     {
         $token = $this->createToken(null, null, Signature::fromEmptyData());
 
-        self::assertEquals('headers.claims.', (string) $token);
+        self::assertSame('headers.claims.', $token->toString());
     }
 
     /**
      * @test
      *
-     * @covers \Lcobucci\JWT\Token\Plain::__toString
+     * @covers \Lcobucci\JWT\Token\Plain::toString
      *
      * @uses \Lcobucci\JWT\Token\Plain::__construct
      * @uses \Lcobucci\JWT\Token\DataSet
@@ -596,6 +596,6 @@ final class PlainTest extends TestCase
     {
         $token = $this->createToken();
 
-        self::assertEquals('headers.claims.signature', (string) $token);
+        self::assertSame('headers.claims.signature', $token->toString());
     }
 }

--- a/test/unit/Token/SignatureTest.php
+++ b/test/unit/Token/SignatureTest.php
@@ -12,7 +12,7 @@ final class SignatureTest extends TestCase
      *
      * @covers \Lcobucci\JWT\Token\Signature::__construct
      * @covers \Lcobucci\JWT\Token\Signature::fromEmptyData
-     * @covers \Lcobucci\JWT\Token\Signature::__toString
+     * @covers \Lcobucci\JWT\Token\Signature::toString
      * @covers \Lcobucci\JWT\Token\Signature::hash
      */
     public function fromEmptyDataShouldReturnAnEmptySignature(): void
@@ -20,7 +20,7 @@ final class SignatureTest extends TestCase
         $signature = Signature::fromEmptyData();
 
         self::assertSame('', $signature->hash());
-        self::assertSame('', (string) $signature);
+        self::assertSame('', $signature->toString());
     }
 
     /**
@@ -28,13 +28,13 @@ final class SignatureTest extends TestCase
      *
      * @covers \Lcobucci\JWT\Token\Signature::__construct
      * @covers \Lcobucci\JWT\Token\Signature::hash
-     * @covers \Lcobucci\JWT\Token\Signature::__toString
+     * @covers \Lcobucci\JWT\Token\Signature::toString
      */
     public function hashShouldReturnTheHash(): void
     {
         $signature = new Signature('test', 'encoded');
 
         self::assertSame('test', $signature->hash());
-        self::assertSame('encoded', (string) $signature);
+        self::assertSame('encoded', $signature->toString());
     }
 }


### PR DESCRIPTION
* add a standard public toString method alongside the magic __toString methods

motivation:
* helps to avoid explicit type casts over Token/Plain class in v4