### PR TITLE
fix php docblock

### DIFF
--- a/src/Signature.php
+++ b/src/Signature.php
@@ -7,6 +7,8 @@
 
 namespace Lcobucci\JWT;
 
+use Lcobucci\JWT\Signer\Key;
+
 /**
  * This class represents a token signature
  *
@@ -38,7 +40,7 @@ class Signature
      *
      * @param Signer $signer
      * @param string $payload
-     * @param string $key
+     * @param Key|string $key
      *
      * @return boolean
      */

--- a/src/Token.php
+++ b/src/Token.php
@@ -12,6 +12,7 @@ use DateTime;
 use DateTimeInterface;
 use Generator;
 use Lcobucci\JWT\Claim\Validatable;
+use Lcobucci\JWT\Signer\Key;
 use OutOfBoundsException;
 
 /**
@@ -182,7 +183,7 @@ class Token
      * Verify if the key matches with the one that created the signature
      *
      * @param Signer $signer
-     * @param string $key
+     * @param Key|string $key
      *
      * @return boolean
      *


### PR DESCRIPTION
token and signature also allow `Key` as key, not only strings