### PR TITLE
`Claim::getValue` can return anything

### DIFF
--- a/src/Claim.php
+++ b/src/Claim.php
@@ -27,7 +27,7 @@ interface Claim extends JsonSerializable
     /**
      * Returns the claim value
      *
-     * @return string
+     * @return mixed
      */
     public function getValue();
 


### PR DESCRIPTION
As reported and discussed via #367, we need to expand the return type of `Claim::getValue`

An example is, https://github.com/lcobucci/jwt/blob/56f10808/src/Claim/Basic.php#L36, which accepts `mixed` as the Claim's value.

Fix #367.