### PR TITLE
Update `getPassphrase` PHPDoc

### DIFF
--- a/src/Signer/Key.php
+++ b/src/Signer/Key.php
@@ -31,7 +31,7 @@ final class Key
      * @param string $content
      * @param string $passphrase
      */
-    public function __construct($content, $passphrase = null)
+    public function __construct($content, $passphrase = '')
     {
         $this->setContent($content);
         $this->passphrase = $passphrase;


### PR DESCRIPTION
The property `passphrase` can be `null` or a string.
I propose to indicate it in the header.

If you really want to return a string, the constructor could be changed in favour of `public function __construct($content, $passphrase = '')`
Let me know if you prefer the later.