### PR TITLE
Use library specific exceptions

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace Lcobucci\JWT;
 
 use DateTimeImmutable;
-use InvalidArgumentException;
 use Lcobucci\JWT\Signer\Key;
 use Lcobucci\JWT\Token\Plain;
 
@@ -57,7 +56,7 @@ interface Builder
      *
      * @param mixed $value
      *
-     * @throws InvalidArgumentException When trying to set a registered claim.
+     * @throws InvalidArgument When trying to set a registered claim.
      */
     public function withClaim(string $name, $value): Builder;
 

--- a/src/InvalidArgument.php
+++ b/src/InvalidArgument.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace Lcobucci\JWT;
+
+use InvalidArgumentException;
+
+final class InvalidArgument extends InvalidArgumentException implements Exception
+{
+}

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -3,14 +3,12 @@ declare(strict_types=1);
 
 namespace Lcobucci\JWT;
 
-use InvalidArgumentException;
-
 interface Parser
 {
     /**
      * Parses the JWT and returns a token
      *
-     * @throws InvalidArgumentException
+     * @throws InvalidArgument
      */
     public function parse(string $jwt): Token;
 }

--- a/src/Signer.php
+++ b/src/Signer.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Lcobucci\JWT;
 
-use InvalidArgumentException;
 use Lcobucci\JWT\Signer\Key;
 
 interface Signer
@@ -16,14 +15,14 @@ interface Signer
     /**
      * Creates a hash for the given payload
      *
-     * @throws InvalidArgumentException When given key is invalid.
+     * @throws InvalidArgument When given key is invalid.
      */
     public function sign(string $payload, Key $key): string;
 
     /**
      * Returns if the expected hash matches with the data and key
      *
-     * @throws InvalidArgumentException When given key is invalid.
+     * @throws InvalidArgument When given key is invalid.
      */
     public function verify(string $expected, string $payload, Key $key): bool;
 }

--- a/src/Signer/Ecdsa/MultibyteStringConverter.php
+++ b/src/Signer/Ecdsa/MultibyteStringConverter.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 
 namespace Lcobucci\JWT\Signer\Ecdsa;
 
-use InvalidArgumentException;
+use Lcobucci\JWT\InvalidArgument;
 
 use function assert;
 use function bin2hex;
@@ -48,7 +48,7 @@ final class MultibyteStringConverter implements SignatureConverter
         $points = bin2hex($points);
 
         if (self::octetLength($points) !== $length) {
-            throw new InvalidArgumentException('Invalid signature length.');
+            throw new InvalidArgument('Invalid signature length.');
         }
 
         $pointR = self::preparePositiveInteger(mb_substr($points, 0, $length, '8bit'));
@@ -98,7 +98,7 @@ final class MultibyteStringConverter implements SignatureConverter
         $position = 0;
 
         if (self::readAsn1Content($message, $position, self::BYTE_SIZE) !== self::ASN1_SEQUENCE) {
-            throw new InvalidArgumentException('Invalid data. Should start with a sequence.');
+            throw new InvalidArgument('Invalid data. Should start with a sequence.');
         }
 
         // @phpstan-ignore-next-line
@@ -126,7 +126,7 @@ final class MultibyteStringConverter implements SignatureConverter
     private static function readAsn1Integer(string $message, int &$position): string
     {
         if (self::readAsn1Content($message, $position, self::BYTE_SIZE) !== self::ASN1_INTEGER) {
-            throw new InvalidArgumentException('Invalid data. Should contain an integer.');
+            throw new InvalidArgument('Invalid data. Should contain an integer.');
         }
 
         $length = (int) hexdec(self::readAsn1Content($message, $position, self::BYTE_SIZE));

--- a/src/Signer/Key.php
+++ b/src/Signer/Key.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Lcobucci\JWT\Signer;
 
-use InvalidArgumentException;
+use Lcobucci\JWT\InvalidArgument;
 use SplFileObject;
 use Throwable;
 
@@ -23,7 +23,7 @@ final class Key
         $this->passphrase = $passphrase;
     }
 
-    /** @throws InvalidArgumentException */
+    /** @throws InvalidArgument */
     private function setContent(string $content): void
     {
         if (strpos($content, 'file://') === 0) {
@@ -33,7 +33,7 @@ final class Key
         $this->content = $content;
     }
 
-    /** @throws InvalidArgumentException */
+    /** @throws InvalidArgument */
     private function readFile(string $path): string
     {
         try {
@@ -43,7 +43,7 @@ final class Key
 
             return $content;
         } catch (Throwable $exception) {
-            throw new InvalidArgumentException('You must provide a valid key file', $exception->getCode(), $exception);
+            throw new InvalidArgument('You must provide a valid key file', $exception->getCode(), $exception);
         }
     }
 

--- a/src/Signer/OpenSSL.php
+++ b/src/Signer/OpenSSL.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Lcobucci\JWT\Signer;
 
-use InvalidArgumentException;
+use Lcobucci\JWT\InvalidArgument;
 use Lcobucci\JWT\Signer;
 use OpenSSLAsymmetricKey;
 
@@ -31,7 +31,7 @@ abstract class OpenSSL implements Signer
             $signature = '';
 
             if (! openssl_sign($payload, $signature, $key, $this->getAlgorithm())) {
-                throw new InvalidArgumentException(
+                throw new InvalidArgument(
                     'There was an error while creating the signature: ' . openssl_error_string()
                 );
             }
@@ -77,12 +77,12 @@ abstract class OpenSSL implements Signer
      *
      * @param resource|OpenSSLAsymmetricKey|bool $key
      *
-     * @throws InvalidArgumentException
+     * @throws InvalidArgument
      */
     private function validateKey($key): void
     {
         if (is_bool($key)) {
-            throw new InvalidArgumentException(
+            throw new InvalidArgument(
                 'It was not possible to parse your key, reason: ' . openssl_error_string()
             );
         }
@@ -91,7 +91,7 @@ abstract class OpenSSL implements Signer
         assert(is_array($details));
 
         if (! isset($details['key']) || $details['type'] !== $this->getKeyType()) {
-            throw new InvalidArgumentException('This key is not compatible with this signer');
+            throw new InvalidArgument('This key is not compatible with this signer');
         }
     }
 

--- a/src/Token/Builder.php
+++ b/src/Token/Builder.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 namespace Lcobucci\JWT\Token;
 
 use DateTimeImmutable;
-use InvalidArgumentException;
 use Lcobucci\JWT\Builder as BuilderInterface;
 use Lcobucci\JWT\ClaimsFormatter;
 use Lcobucci\JWT\Encoder;
+use Lcobucci\JWT\InvalidArgument;
 use Lcobucci\JWT\Signer;
 use Lcobucci\JWT\Signer\Key;
 
@@ -86,7 +86,7 @@ final class Builder implements BuilderInterface
     public function withClaim(string $name, $value): BuilderInterface
     {
         if (in_array($name, RegisteredClaims::ALL, true)) {
-            throw new InvalidArgumentException('You should use the correct methods to set registered claims');
+            throw new InvalidArgument('You should use the correct methods to set registered claims');
         }
 
         return $this->setClaim($name, $value);

--- a/src/Token/Parser.php
+++ b/src/Token/Parser.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 namespace Lcobucci\JWT\Token;
 
 use DateTimeImmutable;
-use InvalidArgumentException;
 use Lcobucci\JWT\Decoder;
+use Lcobucci\JWT\InvalidArgument;
 use Lcobucci\JWT\Parser as ParserInterface;
 use Lcobucci\JWT\Token as TokenInterface;
 
@@ -43,14 +43,14 @@ final class Parser implements ParserInterface
      *
      * @return string[]
      *
-     * @throws InvalidArgumentException When JWT doesn't have all parts.
+     * @throws InvalidArgument When JWT doesn't have all parts.
      */
     private function splitJwt(string $jwt): array
     {
         $data = explode('.', $jwt);
 
         if (count($data) !== 3) {
-            throw new InvalidArgumentException('The JWT string must have two dots');
+            throw new InvalidArgument('The JWT string must have two dots');
         }
 
         return $data;
@@ -61,22 +61,22 @@ final class Parser implements ParserInterface
      *
      * @return mixed[]
      *
-     * @throws InvalidArgumentException When an invalid header is informed.
+     * @throws InvalidArgument When an invalid header is informed.
      */
     private function parseHeader(string $data): array
     {
         $header = $this->decoder->jsonDecode($this->decoder->base64UrlDecode($data));
 
         if (! is_array($header)) {
-            throw new InvalidArgumentException('Headers must be an array');
+            throw new InvalidArgument('Headers must be an array');
         }
 
         if (isset($header['enc'])) {
-            throw new InvalidArgumentException('Encryption is not supported yet');
+            throw new InvalidArgument('Encryption is not supported yet');
         }
 
         if (! isset($header['typ'])) {
-            throw new InvalidArgumentException('The header "typ" must be present');
+            throw new InvalidArgument('The header "typ" must be present');
         }
 
         return $header;
@@ -87,14 +87,14 @@ final class Parser implements ParserInterface
      *
      * @return mixed[]
      *
-     * @throws InvalidArgumentException When an invalid claim set is informed.
+     * @throws InvalidArgument When an invalid claim set is informed.
      */
     private function parseClaims(string $data): array
     {
         $claims = $this->decoder->jsonDecode($this->decoder->base64UrlDecode($data));
 
         if (! is_array($claims)) {
-            throw new InvalidArgumentException('Claims must be an array');
+            throw new InvalidArgument('Claims must be an array');
         }
 
         if (isset($claims[RegisteredClaims::AUDIENCE])) {
@@ -117,7 +117,7 @@ final class Parser implements ParserInterface
         $date = DateTimeImmutable::createFromFormat('U.u', $value);
 
         if ($date === false) {
-            throw new InvalidArgumentException('Given value is not in the allowed format: ' . $value);
+            throw new InvalidArgument('Given value is not in the allowed format: ' . $value);
         }
 
         return $date;

--- a/src/Validation/Constraint/ValidAt.php
+++ b/src/Validation/Constraint/ValidAt.php
@@ -5,8 +5,8 @@ namespace Lcobucci\JWT\Validation\Constraint;
 
 use DateInterval;
 use DateTimeInterface;
-use InvalidArgumentException;
 use Lcobucci\Clock\Clock;
+use Lcobucci\JWT\InvalidArgument;
 use Lcobucci\JWT\Token;
 use Lcobucci\JWT\Validation\Constraint;
 use Lcobucci\JWT\Validation\ConstraintViolation;
@@ -29,7 +29,7 @@ final class ValidAt implements Constraint
         }
 
         if ($leeway->invert === 1) {
-            throw new InvalidArgumentException('Leeway cannot be negative');
+            throw new InvalidArgument('Leeway cannot be negative');
         }
 
         return $leeway;

--- a/test/functional/ES512TokenTest.php
+++ b/test/functional/ES512TokenTest.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace Lcobucci\JWT\FunctionalTests;
 
-use InvalidArgumentException;
 use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\InvalidArgument;
 use Lcobucci\JWT\Keys;
 use Lcobucci\JWT\Signer\Ecdsa\Sha256;
 use Lcobucci\JWT\Signer\Ecdsa\Sha512;
@@ -58,7 +58,7 @@ class ES512TokenTest extends TestCase
     {
         $builder = $this->config->createBuilder();
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgument::class);
         $this->expectExceptionMessage('It was not possible to parse your key, reason:');
 
         $builder->identifiedBy('1')
@@ -73,7 +73,7 @@ class ES512TokenTest extends TestCase
     {
         $builder = $this->config->createBuilder();
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgument::class);
         $this->expectExceptionMessage('This key is not compatible with this signer');
 
         $builder->identifiedBy('1')
@@ -164,7 +164,7 @@ class ES512TokenTest extends TestCase
      */
     public function signatureAssertionShouldRaiseExceptionWhenKeyIsNotEcdsaCompatible(Token $token): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgument::class);
         $this->expectExceptionMessage('This key is not compatible with this signer');
 
         $this->config->getValidator()->assert(

--- a/test/functional/EcdsaTokenTest.php
+++ b/test/functional/EcdsaTokenTest.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace Lcobucci\JWT\FunctionalTests;
 
-use InvalidArgumentException;
 use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\InvalidArgument;
 use Lcobucci\JWT\Keys;
 use Lcobucci\JWT\Signer\Ecdsa\Sha256;
 use Lcobucci\JWT\Signer\Ecdsa\Sha512;
@@ -62,7 +62,7 @@ class EcdsaTokenTest extends TestCase
     {
         $builder = $this->config->createBuilder();
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgument::class);
         $this->expectExceptionMessage('It was not possible to parse your key, reason:');
 
         $builder->identifiedBy('1')
@@ -77,7 +77,7 @@ class EcdsaTokenTest extends TestCase
     {
         $builder = $this->config->createBuilder();
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgument::class);
         $this->expectExceptionMessage('This key is not compatible with this signer');
 
         $builder->identifiedBy('1')
@@ -168,7 +168,7 @@ class EcdsaTokenTest extends TestCase
      */
     public function signatureAssertionShouldRaiseExceptionWhenKeyIsNotEcdsaCompatible(Token $token): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgument::class);
         $this->expectExceptionMessage('This key is not compatible with this signer');
 
         $this->config->getValidator()->assert(

--- a/test/functional/RsaTokenTest.php
+++ b/test/functional/RsaTokenTest.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace Lcobucci\JWT\FunctionalTests;
 
-use InvalidArgumentException;
 use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\InvalidArgument;
 use Lcobucci\JWT\Keys;
 use Lcobucci\JWT\Signer\Key;
 use Lcobucci\JWT\Signer\Rsa\Sha256;
@@ -57,7 +57,7 @@ class RsaTokenTest extends TestCase
     {
         $builder = $this->config->createBuilder();
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgument::class);
         $this->expectExceptionMessage('It was not possible to parse your key');
 
         $builder->identifiedBy('1')
@@ -72,7 +72,7 @@ class RsaTokenTest extends TestCase
     {
         $builder = $this->config->createBuilder();
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgument::class);
         $this->expectExceptionMessage('This key is not compatible with this signer');
 
         $builder->identifiedBy('1')
@@ -152,7 +152,7 @@ class RsaTokenTest extends TestCase
      */
     public function signatureAssertionShouldRaiseExceptionWhenKeyIsNotRsaCompatible(Token $token): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgument::class);
         $this->expectExceptionMessage('This key is not compatible with this signer');
 
         $this->config->getValidator()->assert(

--- a/test/unit/Signer/Ecdsa/MultibyteStringConverterTest.php
+++ b/test/unit/Signer/Ecdsa/MultibyteStringConverterTest.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Lcobucci\JWT\Signer\Ecdsa;
 
-use InvalidArgumentException;
+use Lcobucci\JWT\InvalidArgument;
 use PHPUnit\Framework\TestCase;
 
 use function assert;
@@ -45,7 +45,7 @@ final class MultibyteStringConverterTest extends TestCase
     {
         $converter = new MultibyteStringConverter();
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgument::class);
         $this->expectExceptionMessage('Invalid signature length');
         $converter->toAsn1('a very wrong string', 64);
     }
@@ -112,7 +112,7 @@ final class MultibyteStringConverterTest extends TestCase
         $message   = hex2bin($message);
         assert(is_string($message));
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgument::class);
         $this->expectExceptionMessage($expectedMessage);
         $converter->fromAsn1($message, 64);
     }

--- a/test/unit/Signer/KeyTest.php
+++ b/test/unit/Signer/KeyTest.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Lcobucci\JWT\Signer;
 
-use InvalidArgumentException;
+use Lcobucci\JWT\InvalidArgument;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
 
@@ -29,7 +29,7 @@ final class KeyTest extends TestCase
      */
     public function constructShouldRaiseExceptionWhenFileDoesNotExists(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgument::class);
         $this->expectExceptionMessage('You must provide a valid key file');
 
         new Key('file://' . vfsStream::url('root/test2.pem'));

--- a/test/unit/Signer/RsaTest.php
+++ b/test/unit/Signer/RsaTest.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Lcobucci\JWT\Signer;
 
-use InvalidArgumentException;
+use Lcobucci\JWT\InvalidArgument;
 use Lcobucci\JWT\Keys;
 use OpenSSLAsymmetricKey;
 use PHPUnit\Framework\TestCase;
@@ -65,7 +65,7 @@ KEY;
 
         $signer = $this->getSigner();
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgument::class);
         $this->expectExceptionMessage('There was an error while creating the signature');
 
         $signer->sign('testing', new Key($key));
@@ -83,7 +83,7 @@ KEY;
     {
         $signer = $this->getSigner();
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgument::class);
         $this->expectExceptionMessage('It was not possible to parse your key');
 
         $signer->sign('testing', new Key('blablabla'));
@@ -102,7 +102,7 @@ KEY;
     {
         $signer = $this->getSigner();
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgument::class);
         $this->expectExceptionMessage('This key is not compatible with this signer');
 
         $signer->sign('testing', self::$ecdsaKeys['private']);
@@ -143,7 +143,7 @@ KEY;
     {
         $signer = $this->getSigner();
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgument::class);
         $this->expectExceptionMessage('It was not possible to parse your key');
 
         $signer->verify('testing', 'testing', new Key('blablabla'));
@@ -161,7 +161,7 @@ KEY;
     {
         $signer = $this->getSigner();
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgument::class);
         $this->expectExceptionMessage('It was not possible to parse your key');
 
         $signer->verify('testing', 'testing', self::$ecdsaKeys['private']);

--- a/test/unit/Token/BuilderTest.php
+++ b/test/unit/Token/BuilderTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 namespace Lcobucci\JWT\Token;
 
 use DateTimeImmutable;
-use InvalidArgumentException;
 use Lcobucci\JWT\Encoder;
 use Lcobucci\JWT\Encoding\MicrosecondBasedDateConversion;
+use Lcobucci\JWT\InvalidArgument;
 use Lcobucci\JWT\Signer;
 use Lcobucci\JWT\Signer\Key;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -43,7 +43,7 @@ final class BuilderTest extends TestCase
     {
         $builder = new Builder($this->encoder, new MicrosecondBasedDateConversion());
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgument::class);
         $this->expectExceptionMessage('You should use the correct methods to set registered claims');
 
         $builder->withClaim(RegisteredClaims::ISSUER, 'me');

--- a/test/unit/Token/ParserTest.php
+++ b/test/unit/Token/ParserTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 namespace Lcobucci\JWT\Token;
 
 use DateTimeImmutable;
-use InvalidArgumentException;
 use Lcobucci\JWT\Decoder;
+use Lcobucci\JWT\InvalidArgument;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -38,7 +38,7 @@ final class ParserTest extends TestCase
     {
         $parser = $this->createParser();
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgument::class);
         $this->expectExceptionMessage('The JWT string must have two dots');
 
         $parser->parse('');
@@ -85,7 +85,7 @@ final class ParserTest extends TestCase
 
         $parser = $this->createParser();
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgument::class);
         $this->expectExceptionMessage('Headers must be an array');
 
         $parser->parse('a.a.');
@@ -106,7 +106,7 @@ final class ParserTest extends TestCase
 
         $parser = $this->createParser();
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgument::class);
         $this->expectExceptionMessage('The header "typ" must be present');
 
         $parser->parse('a.a.');
@@ -127,7 +127,7 @@ final class ParserTest extends TestCase
 
         $parser = $this->createParser();
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgument::class);
         $this->expectExceptionMessage('Encryption is not supported yet');
 
         $parser->parse('a.a.');
@@ -151,7 +151,7 @@ final class ParserTest extends TestCase
 
         $parser = $this->createParser();
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgument::class);
         $this->expectExceptionMessage('Claims must be an array');
 
         $parser->parse('a.a.');
@@ -457,7 +457,7 @@ final class ParserTest extends TestCase
                 $data
             );
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgument::class);
         $this->expectExceptionMessage('Given value is not in the allowed format: 14/10/2018 10:50:10.10 UTC');
         $this->createParser()->parse('a.b.');
     }

--- a/test/unit/Validation/Constraint/ValidAtTest.php
+++ b/test/unit/Validation/Constraint/ValidAtTest.php
@@ -5,9 +5,9 @@ namespace Lcobucci\JWT\Validation\Constraint;
 
 use DateInterval;
 use DateTimeImmutable;
-use InvalidArgumentException;
 use Lcobucci\Clock\Clock;
 use Lcobucci\Clock\FrozenClock;
+use Lcobucci\JWT\InvalidArgument;
 use Lcobucci\JWT\Token\RegisteredClaims;
 use Lcobucci\JWT\Validation\ConstraintViolation;
 
@@ -33,7 +33,7 @@ final class ValidAtTest extends ConstraintTestCase
         $leeway         = new DateInterval('PT30S');
         $leeway->invert = 1;
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgument::class);
         $this->expectExceptionMessage('Leeway cannot be negative');
 
         new ValidAt($this->clock, $leeway);


### PR DESCRIPTION
I added a new Exception class named `InvalidArgument` in order to replace the SPL `InvalidArgumentException` class.
Tests have been updated.

Fix #128