### PR TITLE
Fix base exception concept

### DIFF
--- a/src/Exception.php
+++ b/src/Exception.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace Lcobucci\JWT;
 
-use RuntimeException;
+use Throwable;
 
-abstract class Exception extends RuntimeException
+interface Exception extends Throwable
 {
 }

--- a/src/Validation/ConstraintViolation.php
+++ b/src/Validation/ConstraintViolation.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 namespace Lcobucci\JWT\Validation;
 
 use Lcobucci\JWT\Exception;
+use RuntimeException;
 
-final class ConstraintViolation extends Exception
+final class ConstraintViolation extends RuntimeException implements Exception
 {
 }

--- a/src/Validation/InvalidToken.php
+++ b/src/Validation/InvalidToken.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 namespace Lcobucci\JWT\Validation;
 
 use Lcobucci\JWT\Exception;
+use RuntimeException;
 
 use function array_map;
 use function implode;
 
-final class InvalidToken extends Exception
+final class InvalidToken extends RuntimeException implements Exception
 {
     /** @var ConstraintViolation[] */
     private array $violations = [];

--- a/src/Validation/NoConstraintsGiven.php
+++ b/src/Validation/NoConstraintsGiven.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 namespace Lcobucci\JWT\Validation;
 
 use Lcobucci\JWT\Exception;
+use RuntimeException;
 
-final class NoConstraintsGiven extends Exception
+final class NoConstraintsGiven extends RuntimeException implements Exception
 {
 }


### PR DESCRIPTION
This address the design issue introduced when we first created a base exception.

The issue with the previous version is that we'd always have exceptions that inherit from `RuntimeException`, which might not always be appropriated.

Using a marker interface as base exception allows for more fine-grained control over the exception design, making it also better
for users to catch exceptional cases.