### PR TITLE
Pull JOSE encoder back

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,7 @@
         "php": "^7.4 || ^8.0",
         "ext-mbstring": "*",
         "ext-openssl": "*",
-        "lcobucci/clock": "^2.0",
-        "lcobucci/jose-parsing": "^3.0"
+        "lcobucci/clock": "^2.0"
     },
     "require-dev": {
         "infection/infection": "^0.20",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3b6367a93e4144ec69226e976a351238",
+    "content-hash": "36f5b286daebc58d9834b6e695dba174",
     "packages": [
         {
             "name": "lcobucci/clock",
@@ -62,73 +62,6 @@
                 }
             ],
             "time": "2020-08-27T18:56:02+00:00"
-        },
-        {
-            "name": "lcobucci/jose-parsing",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/lcobucci/jose-parsing.git",
-                "reference": "7808caa6f0b9f35b6244aa244ff989f619d62b4c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/lcobucci/jose-parsing/zipball/7808caa6f0b9f35b6244aa244ff989f619d62b4c",
-                "reference": "7808caa6f0b9f35b6244aa244ff989f619d62b4c",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "php": "^7.4 || ^8.0"
-            },
-            "require-dev": {
-                "infection/infection": "^0.16",
-                "lcobucci/coding-standard": "^4.0",
-                "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^0.12",
-                "phpstan/phpstan-deprecation-rules": "^0.12",
-                "phpstan/phpstan-phpunit": "^0.12",
-                "phpstan/phpstan-strict-rules": "^0.12",
-                "phpunit/phpunit": "^9.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Lcobucci\\Jose\\Parsing\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Luís Cobucci",
-                    "email": "lcobucci@gmail.com",
-                    "role": "Developer"
-                }
-            ],
-            "description": "A basic Base64Url and JSON encoding/decoding implementation",
-            "keywords": [
-                "JOSE",
-                "base64url"
-            ],
-            "funding": [
-                {
-                    "url": "https://github.com/lcobucci",
-                    "type": "github"
-                },
-                {
-                    "url": "https://www.patreon.com/lcobucci",
-                    "type": "patreon"
-                }
-            ],
-            "time": "2020-05-22T12:42:30+00:00"
         }
     ],
     "packages-dev": [
@@ -5136,5 +5069,5 @@
         "ext-openssl": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace Lcobucci\JWT;
 
 use Closure;
-use Lcobucci\Jose\Parsing;
+use Lcobucci\JWT\Encoding\JoseEncoder;
 use Lcobucci\JWT\Signer\Key;
 use Lcobucci\JWT\Signer\None;
 use Lcobucci\JWT\Validation\Constraint;
@@ -33,17 +33,17 @@ final class Configuration
         Signer $signer,
         Key $signingKey,
         Key $verificationKey,
-        ?Parsing\Encoder $encoder = null,
-        ?Parsing\Decoder $decoder = null
+        ?Encoder $encoder = null,
+        ?Decoder $decoder = null
     ) {
         $this->signer          = $signer;
         $this->signingKey      = $signingKey;
         $this->verificationKey = $verificationKey;
-        $this->parser          = new Token\Parser($decoder ?? new Parsing\Parser());
+        $this->parser          = new Token\Parser($decoder ?? new JoseEncoder());
         $this->validator       = new Validation\Validator();
 
         $this->builderFactory = static function () use ($encoder): Builder {
-            return new Token\Builder($encoder ?? new Parsing\Parser());
+            return new Token\Builder($encoder ?? new JoseEncoder());
         };
     }
 
@@ -51,8 +51,8 @@ final class Configuration
         Signer $signer,
         Key $signingKey,
         Key $verificationKey,
-        ?Parsing\Encoder $encoder = null,
-        ?Parsing\Decoder $decoder = null
+        ?Encoder $encoder = null,
+        ?Decoder $decoder = null
     ): self {
         return new self(
             $signer,
@@ -66,8 +66,8 @@ final class Configuration
     public static function forSymmetricSigner(
         Signer $signer,
         Key $key,
-        ?Parsing\Encoder $encoder = null,
-        ?Parsing\Decoder $decoder = null
+        ?Encoder $encoder = null,
+        ?Decoder $decoder = null
     ): self {
         return new self(
             $signer,
@@ -79,8 +79,8 @@ final class Configuration
     }
 
     public static function forUnsecuredSigner(
-        ?Parsing\Encoder $encoder = null,
-        ?Parsing\Decoder $decoder = null
+        ?Encoder $encoder = null,
+        ?Decoder $decoder = null
     ): self {
         $key = new Key('');
 

--- a/src/Decoder.php
+++ b/src/Decoder.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Lcobucci\JWT;
+
+use Lcobucci\JWT\Encoding\CannotDecodeContent;
+
+interface Decoder
+{
+    /**
+     * Decodes from JSON, validating the errors
+     *
+     * @return mixed
+     *
+     * @throws CannotDecodeContent When something goes wrong while decoding.
+     */
+    public function jsonDecode(string $json);
+
+    /**
+     * Decodes from Base64URL
+     *
+     * @link http://tools.ietf.org/html/rfc4648#section-5
+     *
+     * @throws CannotDecodeContent When something goes wrong while decoding.
+     */
+    public function base64UrlDecode(string $data): string;
+}

--- a/src/Encoder.php
+++ b/src/Encoder.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Lcobucci\JWT;
+
+use Lcobucci\JWT\Encoding\CannotEncodeContent;
+
+interface Encoder
+{
+    /**
+     * Encodes to JSON, validating the errors
+     *
+     * @param mixed $data
+     *
+     * @throws CannotEncodeContent When something goes wrong while encoding.
+     */
+    public function jsonEncode($data): string;
+
+    /**
+     * Encodes to base64url
+     *
+     * @link http://tools.ietf.org/html/rfc4648#section-5
+     */
+    public function base64UrlEncode(string $data): string;
+}

--- a/src/Encoding/CannotDecodeContent.php
+++ b/src/Encoding/CannotDecodeContent.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace Lcobucci\JWT\Encoding;
+
+use JsonException;
+use Lcobucci\JWT\Exception;
+use RuntimeException;
+
+final class CannotDecodeContent extends RuntimeException implements Exception
+{
+    public static function jsonIssues(JsonException $previous): self
+    {
+        return new self('Error while decoding from JSON', 0, $previous);
+    }
+
+    public static function invalidBase64String(): self
+    {
+        return new self('Error while decoding from Base64Url, invalid base64 characters detected');
+    }
+}

--- a/src/Encoding/CannotEncodeContent.php
+++ b/src/Encoding/CannotEncodeContent.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace Lcobucci\JWT\Encoding;
+
+use JsonException;
+use Lcobucci\JWT\Exception;
+use RuntimeException;
+
+final class CannotEncodeContent extends RuntimeException implements Exception
+{
+    public static function jsonIssues(JsonException $previous): self
+    {
+        return new self('Error while encoding to JSON', 0, $previous);
+    }
+}

--- a/src/Encoding/JoseEncoder.php
+++ b/src/Encoding/JoseEncoder.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+namespace Lcobucci\JWT\Encoding;
+
+use JsonException;
+use Lcobucci\JWT\Decoder;
+use Lcobucci\JWT\Encoder;
+
+use function base64_decode;
+use function base64_encode;
+use function is_string;
+use function json_decode;
+use function json_encode;
+use function rtrim;
+use function strtr;
+
+use const JSON_THROW_ON_ERROR;
+use const JSON_UNESCAPED_SLASHES;
+use const JSON_UNESCAPED_UNICODE;
+
+/**
+ * A utilitarian class that encodes and decodes data according with JOSE specifications
+ */
+final class JoseEncoder implements Encoder, Decoder
+{
+    private const JSON_DEFAULT_DEPTH = 512;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function jsonEncode($data): string
+    {
+        try {
+            return json_encode($data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw CannotEncodeContent::jsonIssues($exception);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function jsonDecode(string $json)
+    {
+        try {
+            return json_decode($json, true, self::JSON_DEFAULT_DEPTH, JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw CannotDecodeContent::jsonIssues($exception);
+        }
+    }
+
+    public function base64UrlEncode(string $data): string
+    {
+        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+    }
+
+    public function base64UrlDecode(string $data): string
+    {
+        // Padding isn't added back because it isn't strictly necessary for decoding with PHP
+        $decodedContent = base64_decode(strtr($data, '-_', '+/'), true);
+
+        if (! is_string($decodedContent)) {
+            throw CannotDecodeContent::invalidBase64String();
+        }
+
+        return $decodedContent;
+    }
+}

--- a/src/Token/Builder.php
+++ b/src/Token/Builder.php
@@ -5,8 +5,8 @@ namespace Lcobucci\JWT\Token;
 
 use DateTimeImmutable;
 use InvalidArgumentException;
-use Lcobucci\Jose\Parsing;
 use Lcobucci\JWT\Builder as BuilderInterface;
+use Lcobucci\JWT\Encoder;
 use Lcobucci\JWT\Signer;
 use Lcobucci\JWT\Signer\Key;
 
@@ -26,9 +26,9 @@ final class Builder implements BuilderInterface
     /** @var array<string, mixed> */
     private array $claims = [];
 
-    private Parsing\Encoder $encoder;
+    private Encoder $encoder;
 
-    public function __construct(Parsing\Encoder $encoder)
+    public function __construct(Encoder $encoder)
     {
         $this->encoder = $encoder;
     }

--- a/src/Token/Parser.php
+++ b/src/Token/Parser.php
@@ -5,7 +5,7 @@ namespace Lcobucci\JWT\Token;
 
 use DateTimeImmutable;
 use InvalidArgumentException;
-use Lcobucci\Jose\Parsing;
+use Lcobucci\JWT\Decoder;
 use Lcobucci\JWT\Parser as ParserInterface;
 use Lcobucci\JWT\Token as TokenInterface;
 
@@ -18,9 +18,9 @@ use function strpos;
 
 final class Parser implements ParserInterface
 {
-    private Parsing\Decoder $decoder;
+    private Decoder $decoder;
 
-    public function __construct(Parsing\Decoder $decoder)
+    public function __construct(Decoder $decoder)
     {
         $this->decoder = $decoder;
     }

--- a/test/functional/ES512TokenTest.php
+++ b/test/functional/ES512TokenTest.php
@@ -18,6 +18,7 @@ use function assert;
 
 /**
  * @covers \Lcobucci\JWT\Configuration
+ * @covers \Lcobucci\JWT\Encoding\JoseEncoder
  * @covers \Lcobucci\JWT\Token\Builder
  * @covers \Lcobucci\JWT\Token\Parser
  * @covers \Lcobucci\JWT\Token\Plain

--- a/test/functional/ES512TokenTest.php
+++ b/test/functional/ES512TokenTest.php
@@ -16,6 +16,23 @@ use PHPUnit\Framework\TestCase;
 
 use function assert;
 
+/**
+ * @covers \Lcobucci\JWT\Configuration
+ * @covers \Lcobucci\JWT\Token\Builder
+ * @covers \Lcobucci\JWT\Token\Parser
+ * @covers \Lcobucci\JWT\Token\Plain
+ * @covers \Lcobucci\JWT\Token\DataSet
+ * @covers \Lcobucci\JWT\Token\Signature
+ * @covers \Lcobucci\JWT\Signer\Key
+ * @covers \Lcobucci\JWT\Signer\Ecdsa
+ * @covers \Lcobucci\JWT\Signer\Ecdsa\MultibyteStringConverter
+ * @covers \Lcobucci\JWT\Signer\Ecdsa\Sha256
+ * @covers \Lcobucci\JWT\Signer\Ecdsa\Sha512
+ * @covers \Lcobucci\JWT\Signer\OpenSSL
+ * @covers \Lcobucci\JWT\Validation\Validator
+ * @covers \Lcobucci\JWT\Validation\InvalidToken
+ * @covers \Lcobucci\JWT\Validation\Constraint\SignedWith
+ */
 class ES512TokenTest extends TestCase
 {
     use Keys;
@@ -32,21 +49,7 @@ class ES512TokenTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     *
-     * @covers \Lcobucci\JWT\Configuration
-     * @covers \Lcobucci\JWT\Token\Builder
-     * @covers \Lcobucci\JWT\Token\Parser
-     * @covers \Lcobucci\JWT\Token\Plain
-     * @covers \Lcobucci\JWT\Token\DataSet
-     * @covers \Lcobucci\JWT\Token\Signature
-     * @covers \Lcobucci\JWT\Signer\Key
-     * @covers \Lcobucci\JWT\Signer\Ecdsa
-     * @covers \Lcobucci\JWT\Signer\Ecdsa\MultibyteStringConverter
-     * @covers \Lcobucci\JWT\Signer\Ecdsa\Sha512
-     * @covers \Lcobucci\JWT\Signer\OpenSSL
-     */
+    /** @test */
     public function builderShouldRaiseExceptionWhenKeyIsInvalid(): void
     {
         $builder = $this->config->createBuilder();
@@ -61,21 +64,7 @@ class ES512TokenTest extends TestCase
             ->getToken($this->config->getSigner(), new Key('testing'));
     }
 
-    /**
-     * @test
-     *
-     * @covers \Lcobucci\JWT\Configuration
-     * @covers \Lcobucci\JWT\Token\Builder
-     * @covers \Lcobucci\JWT\Token\Parser
-     * @covers \Lcobucci\JWT\Token\Plain
-     * @covers \Lcobucci\JWT\Token\DataSet
-     * @covers \Lcobucci\JWT\Token\Signature
-     * @covers \Lcobucci\JWT\Signer\Key
-     * @covers \Lcobucci\JWT\Signer\Ecdsa
-     * @covers \Lcobucci\JWT\Signer\Ecdsa\MultibyteStringConverter
-     * @covers \Lcobucci\JWT\Signer\Ecdsa\Sha512
-     * @covers \Lcobucci\JWT\Signer\OpenSSL
-     */
+    /** @test */
     public function builderShouldRaiseExceptionWhenKeyIsNotEcdsaCompatible(): void
     {
         $builder = $this->config->createBuilder();
@@ -90,21 +79,7 @@ class ES512TokenTest extends TestCase
             ->getToken($this->config->getSigner(), static::$rsaKeys['private']);
     }
 
-    /**
-     * @test
-     *
-     * @covers \Lcobucci\JWT\Configuration
-     * @covers \Lcobucci\JWT\Token\Builder
-     * @covers \Lcobucci\JWT\Token\Parser
-     * @covers \Lcobucci\JWT\Token\Plain
-     * @covers \Lcobucci\JWT\Token\DataSet
-     * @covers \Lcobucci\JWT\Token\Signature
-     * @covers \Lcobucci\JWT\Signer\Key
-     * @covers \Lcobucci\JWT\Signer\Ecdsa
-     * @covers \Lcobucci\JWT\Signer\Ecdsa\MultibyteStringConverter
-     * @covers \Lcobucci\JWT\Signer\Ecdsa\Sha512
-     * @covers \Lcobucci\JWT\Signer\OpenSSL
-     */
+    /** @test */
     public function builderCanGenerateAToken(): Token
     {
         $user    = ['name' => 'testing', 'email' => 'testing@abc.com'];
@@ -133,16 +108,6 @@ class ES512TokenTest extends TestCase
     /**
      * @test
      * @depends builderCanGenerateAToken
-     *
-     * @covers \Lcobucci\JWT\Configuration
-     * @covers \Lcobucci\JWT\Token\Builder
-     * @covers \Lcobucci\JWT\Token\Parser
-     * @covers \Lcobucci\JWT\Token\Plain
-     * @covers \Lcobucci\JWT\Token\DataSet
-     * @covers \Lcobucci\JWT\Token\Signature
-     * @covers \Lcobucci\JWT\Signer\Ecdsa
-     * @covers \Lcobucci\JWT\Signer\Ecdsa\MultibyteStringConverter
-     * @covers \Lcobucci\JWT\Signer\OpenSSL
      */
     public function parserCanReadAToken(Token $generated): void
     {
@@ -156,21 +121,6 @@ class ES512TokenTest extends TestCase
     /**
      * @test
      * @depends builderCanGenerateAToken
-     *
-     * @covers \Lcobucci\JWT\Configuration
-     * @covers \Lcobucci\JWT\Token\Builder
-     * @covers \Lcobucci\JWT\Token\Parser
-     * @covers \Lcobucci\JWT\Token\Plain
-     * @covers \Lcobucci\JWT\Token\DataSet
-     * @covers \Lcobucci\JWT\Token\Signature
-     * @covers \Lcobucci\JWT\Signer\Key
-     * @covers \Lcobucci\JWT\Signer\Ecdsa
-     * @covers \Lcobucci\JWT\Signer\Ecdsa\MultibyteStringConverter
-     * @covers \Lcobucci\JWT\Signer\Ecdsa\Sha512
-     * @covers \Lcobucci\JWT\Signer\OpenSSL
-     * @covers \Lcobucci\JWT\Validation\Validator
-     * @covers \Lcobucci\JWT\Validation\InvalidToken
-     * @covers \Lcobucci\JWT\Validation\Constraint\SignedWith
      */
     public function signatureAssertionShouldRaiseExceptionWhenKeyIsNotRight(Token $token): void
     {
@@ -189,22 +139,6 @@ class ES512TokenTest extends TestCase
     /**
      * @test
      * @depends builderCanGenerateAToken
-     *
-     * @covers \Lcobucci\JWT\Configuration
-     * @covers \Lcobucci\JWT\Token\Builder
-     * @covers \Lcobucci\JWT\Token\Parser
-     * @covers \Lcobucci\JWT\Token\Plain
-     * @covers \Lcobucci\JWT\Token\DataSet
-     * @covers \Lcobucci\JWT\Token\Signature
-     * @covers \Lcobucci\JWT\Signer\Key
-     * @covers \Lcobucci\JWT\Signer\Ecdsa
-     * @covers \Lcobucci\JWT\Signer\Ecdsa\MultibyteStringConverter
-     * @covers \Lcobucci\JWT\Signer\Ecdsa\Sha256
-     * @covers \Lcobucci\JWT\Signer\Ecdsa\Sha512
-     * @covers \Lcobucci\JWT\Signer\OpenSSL
-     * @covers \Lcobucci\JWT\Validation\Validator
-     * @covers \Lcobucci\JWT\Validation\InvalidToken
-     * @covers \Lcobucci\JWT\Validation\Constraint\SignedWith
      */
     public function signatureAssertionShouldRaiseExceptionWhenAlgorithmIsDifferent(Token $token): void
     {

--- a/test/functional/EcdsaTokenTest.php
+++ b/test/functional/EcdsaTokenTest.php
@@ -18,6 +18,25 @@ use function assert;
 
 use const PHP_EOL;
 
+/**
+ * @covers \Lcobucci\JWT\Configuration
+ * @covers \Lcobucci\JWT\Token\Builder
+ * @covers \Lcobucci\JWT\Token\Parser
+ * @covers \Lcobucci\JWT\Token\Plain
+ * @covers \Lcobucci\JWT\Token\DataSet
+ * @covers \Lcobucci\JWT\Token\Signature
+ * @covers \Lcobucci\JWT\Signer\Key
+ * @covers \Lcobucci\JWT\Signer\Ecdsa
+ * @covers \Lcobucci\JWT\Signer\Ecdsa\MultibyteStringConverter
+ * @covers \Lcobucci\JWT\Signer\Ecdsa\Sha256
+ * @covers \Lcobucci\JWT\Signer\Ecdsa\Sha512
+ * @covers \Lcobucci\JWT\Signer\OpenSSL
+ * @covers \Lcobucci\JWT\Validation\Validator
+ * @covers \Lcobucci\JWT\Validation\Constraint\SignedWith
+ * @covers \Lcobucci\JWT\Validation\Validator
+ * @covers \Lcobucci\JWT\Validation\InvalidToken
+ * @covers \Lcobucci\JWT\Validation\Constraint\SignedWith
+ */
 class EcdsaTokenTest extends TestCase
 {
     use Keys;
@@ -34,21 +53,7 @@ class EcdsaTokenTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     *
-     * @covers \Lcobucci\JWT\Configuration
-     * @covers \Lcobucci\JWT\Token\Builder
-     * @covers \Lcobucci\JWT\Token\Parser
-     * @covers \Lcobucci\JWT\Token\Plain
-     * @covers \Lcobucci\JWT\Token\DataSet
-     * @covers \Lcobucci\JWT\Token\Signature
-     * @covers \Lcobucci\JWT\Signer\Key
-     * @covers \Lcobucci\JWT\Signer\Ecdsa
-     * @covers \Lcobucci\JWT\Signer\Ecdsa\MultibyteStringConverter
-     * @covers \Lcobucci\JWT\Signer\Ecdsa\Sha256
-     * @covers \Lcobucci\JWT\Signer\OpenSSL
-     */
+    /** @test */
     public function builderShouldRaiseExceptionWhenKeyIsInvalid(): void
     {
         $builder = $this->config->createBuilder();
@@ -63,21 +68,7 @@ class EcdsaTokenTest extends TestCase
                 ->getToken($this->config->getSigner(), new Key('testing'));
     }
 
-    /**
-     * @test
-     *
-     * @covers \Lcobucci\JWT\Configuration
-     * @covers \Lcobucci\JWT\Token\Builder
-     * @covers \Lcobucci\JWT\Token\Parser
-     * @covers \Lcobucci\JWT\Token\Plain
-     * @covers \Lcobucci\JWT\Token\DataSet
-     * @covers \Lcobucci\JWT\Token\Signature
-     * @covers \Lcobucci\JWT\Signer\Key
-     * @covers \Lcobucci\JWT\Signer\Ecdsa
-     * @covers \Lcobucci\JWT\Signer\Ecdsa\MultibyteStringConverter
-     * @covers \Lcobucci\JWT\Signer\Ecdsa\Sha256
-     * @covers \Lcobucci\JWT\Signer\OpenSSL
-     */
+    /** @test */
     public function builderShouldRaiseExceptionWhenKeyIsNotEcdsaCompatible(): void
     {
         $builder = $this->config->createBuilder();
@@ -92,21 +83,7 @@ class EcdsaTokenTest extends TestCase
                 ->getToken($this->config->getSigner(), static::$rsaKeys['private']);
     }
 
-    /**
-     * @test
-     *
-     * @covers \Lcobucci\JWT\Configuration
-     * @covers \Lcobucci\JWT\Token\Builder
-     * @covers \Lcobucci\JWT\Token\Parser
-     * @covers \Lcobucci\JWT\Token\Plain
-     * @covers \Lcobucci\JWT\Token\DataSet
-     * @covers \Lcobucci\JWT\Token\Signature
-     * @covers \Lcobucci\JWT\Signer\Key
-     * @covers \Lcobucci\JWT\Signer\Ecdsa
-     * @covers \Lcobucci\JWT\Signer\Ecdsa\MultibyteStringConverter
-     * @covers \Lcobucci\JWT\Signer\Ecdsa\Sha256
-     * @covers \Lcobucci\JWT\Signer\OpenSSL
-     */
+    /** @test */
     public function builderCanGenerateAToken(): Token
     {
         $user    = ['name' => 'testing', 'email' => 'testing@abc.com'];
@@ -135,16 +112,6 @@ class EcdsaTokenTest extends TestCase
     /**
      * @test
      * @depends builderCanGenerateAToken
-     *
-     * @covers \Lcobucci\JWT\Configuration
-     * @covers \Lcobucci\JWT\Token\Builder
-     * @covers \Lcobucci\JWT\Token\Parser
-     * @covers \Lcobucci\JWT\Token\Plain
-     * @covers \Lcobucci\JWT\Token\DataSet
-     * @covers \Lcobucci\JWT\Token\Signature
-     * @covers \Lcobucci\JWT\Signer\Ecdsa
-     * @covers \Lcobucci\JWT\Signer\Ecdsa\MultibyteStringConverter
-     * @covers \Lcobucci\JWT\Signer\OpenSSL
      */
     public function parserCanReadAToken(Token $generated): void
     {
@@ -158,21 +125,6 @@ class EcdsaTokenTest extends TestCase
     /**
      * @test
      * @depends builderCanGenerateAToken
-     *
-     * @covers \Lcobucci\JWT\Configuration
-     * @covers \Lcobucci\JWT\Token\Builder
-     * @covers \Lcobucci\JWT\Token\Parser
-     * @covers \Lcobucci\JWT\Token\Plain
-     * @covers \Lcobucci\JWT\Token\DataSet
-     * @covers \Lcobucci\JWT\Token\Signature
-     * @covers \Lcobucci\JWT\Signer\Key
-     * @covers \Lcobucci\JWT\Signer\Ecdsa
-     * @covers \Lcobucci\JWT\Signer\Ecdsa\MultibyteStringConverter
-     * @covers \Lcobucci\JWT\Signer\Ecdsa\Sha256
-     * @covers \Lcobucci\JWT\Signer\OpenSSL
-     * @covers \Lcobucci\JWT\Validation\Validator
-     * @covers \Lcobucci\JWT\Validation\InvalidToken
-     * @covers \Lcobucci\JWT\Validation\Constraint\SignedWith
      */
     public function signatureAssertionShouldRaiseExceptionWhenKeyIsNotRight(Token $token): void
     {
@@ -191,22 +143,6 @@ class EcdsaTokenTest extends TestCase
     /**
      * @test
      * @depends builderCanGenerateAToken
-     *
-     * @covers \Lcobucci\JWT\Configuration
-     * @covers \Lcobucci\JWT\Token\Builder
-     * @covers \Lcobucci\JWT\Token\Parser
-     * @covers \Lcobucci\JWT\Token\Plain
-     * @covers \Lcobucci\JWT\Token\DataSet
-     * @covers \Lcobucci\JWT\Token\Signature
-     * @covers \Lcobucci\JWT\Signer\Key
-     * @covers \Lcobucci\JWT\Signer\Ecdsa
-     * @covers \Lcobucci\JWT\Signer\Ecdsa\MultibyteStringConverter
-     * @covers \Lcobucci\JWT\Signer\Ecdsa\Sha256
-     * @covers \Lcobucci\JWT\Signer\Ecdsa\Sha512
-     * @covers \Lcobucci\JWT\Signer\OpenSSL
-     * @covers \Lcobucci\JWT\Validation\Validator
-     * @covers \Lcobucci\JWT\Validation\InvalidToken
-     * @covers \Lcobucci\JWT\Validation\Constraint\SignedWith
      */
     public function signatureAssertionShouldRaiseExceptionWhenAlgorithmIsDifferent(Token $token): void
     {
@@ -225,21 +161,6 @@ class EcdsaTokenTest extends TestCase
     /**
      * @test
      * @depends builderCanGenerateAToken
-     *
-     * @covers \Lcobucci\JWT\Configuration
-     * @covers \Lcobucci\JWT\Token\Builder
-     * @covers \Lcobucci\JWT\Token\Parser
-     * @covers \Lcobucci\JWT\Token\Plain
-     * @covers \Lcobucci\JWT\Token\DataSet
-     * @covers \Lcobucci\JWT\Token\Signature
-     * @covers \Lcobucci\JWT\Signer\Key
-     * @covers \Lcobucci\JWT\Signer\Ecdsa
-     * @covers \Lcobucci\JWT\Signer\Ecdsa\MultibyteStringConverter
-     * @covers \Lcobucci\JWT\Signer\Ecdsa\Sha256
-     * @covers \Lcobucci\JWT\Signer\OpenSSL
-     * @covers \Lcobucci\JWT\Validation\Validator
-     * @covers \Lcobucci\JWT\Validation\InvalidToken
-     * @covers \Lcobucci\JWT\Validation\Constraint\SignedWith
      */
     public function signatureAssertionShouldRaiseExceptionWhenKeyIsNotEcdsaCompatible(Token $token): void
     {
@@ -255,20 +176,6 @@ class EcdsaTokenTest extends TestCase
     /**
      * @test
      * @depends builderCanGenerateAToken
-     *
-     * @covers \Lcobucci\JWT\Configuration
-     * @covers \Lcobucci\JWT\Token\Builder
-     * @covers \Lcobucci\JWT\Token\Parser
-     * @covers \Lcobucci\JWT\Token\Plain
-     * @covers \Lcobucci\JWT\Token\DataSet
-     * @covers \Lcobucci\JWT\Token\Signature
-     * @covers \Lcobucci\JWT\Signer\Key
-     * @covers \Lcobucci\JWT\Signer\Ecdsa
-     * @covers \Lcobucci\JWT\Signer\Ecdsa\MultibyteStringConverter
-     * @covers \Lcobucci\JWT\Signer\Ecdsa\Sha256
-     * @covers \Lcobucci\JWT\Signer\OpenSSL
-     * @covers \Lcobucci\JWT\Validation\Validator
-     * @covers \Lcobucci\JWT\Validation\Constraint\SignedWith
      */
     public function signatureValidationShouldSucceedWhenKeyIsRight(Token $token): void
     {
@@ -280,23 +187,7 @@ class EcdsaTokenTest extends TestCase
         self::assertTrue($this->config->getValidator()->validate($token, $constraint));
     }
 
-    /**
-     * @test
-     *
-     * @covers \Lcobucci\JWT\Configuration
-     * @covers \Lcobucci\JWT\Token\Builder
-     * @covers \Lcobucci\JWT\Token\Parser
-     * @covers \Lcobucci\JWT\Token\Plain
-     * @covers \Lcobucci\JWT\Token\DataSet
-     * @covers \Lcobucci\JWT\Token\Signature
-     * @covers \Lcobucci\JWT\Signer\Key
-     * @covers \Lcobucci\JWT\Signer\Ecdsa
-     * @covers \Lcobucci\JWT\Signer\Ecdsa\MultibyteStringConverter
-     * @covers \Lcobucci\JWT\Signer\Ecdsa\Sha256
-     * @covers \Lcobucci\JWT\Signer\OpenSSL
-     * @covers \Lcobucci\JWT\Validation\Validator
-     * @covers \Lcobucci\JWT\Validation\Constraint\SignedWith
-     */
+    /** @test */
     public function everythingShouldWorkWithAKeyWithParams(): void
     {
         $builder = $this->config->createBuilder();
@@ -317,23 +208,7 @@ class EcdsaTokenTest extends TestCase
         self::assertTrue($this->config->getValidator()->validate($token, $constraint));
     }
 
-    /**
-     * @test
-     *
-     * @covers \Lcobucci\JWT\Configuration
-     * @covers \Lcobucci\JWT\Token\Builder
-     * @covers \Lcobucci\JWT\Token\Parser
-     * @covers \Lcobucci\JWT\Token\Plain
-     * @covers \Lcobucci\JWT\Token\DataSet
-     * @covers \Lcobucci\JWT\Token\Signature
-     * @covers \Lcobucci\JWT\Signer\Key
-     * @covers \Lcobucci\JWT\Signer\Ecdsa
-     * @covers \Lcobucci\JWT\Signer\Ecdsa\MultibyteStringConverter
-     * @covers \Lcobucci\JWT\Signer\Ecdsa\Sha512
-     * @covers \Lcobucci\JWT\Signer\OpenSSL
-     * @covers \Lcobucci\JWT\Validation\Validator
-     * @covers \Lcobucci\JWT\Validation\Constraint\SignedWith
-     */
+    /** @test */
     public function everythingShouldWorkWhenUsingATokenGeneratedByOtherLibs(): void
     {
         $data = 'eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJoZWxsbyI6IndvcmxkIn0.'

--- a/test/functional/EcdsaTokenTest.php
+++ b/test/functional/EcdsaTokenTest.php
@@ -20,6 +20,7 @@ use const PHP_EOL;
 
 /**
  * @covers \Lcobucci\JWT\Configuration
+ * @covers \Lcobucci\JWT\Encoding\JoseEncoder
  * @covers \Lcobucci\JWT\Token\Builder
  * @covers \Lcobucci\JWT\Token\Parser
  * @covers \Lcobucci\JWT\Token\Plain

--- a/test/functional/HmacTokenTest.php
+++ b/test/functional/HmacTokenTest.php
@@ -16,6 +16,7 @@ use function assert;
 
 /**
  * @covers \Lcobucci\JWT\Configuration
+ * @covers \Lcobucci\JWT\Encoding\JoseEncoder
  * @covers \Lcobucci\JWT\Token\Builder
  * @covers \Lcobucci\JWT\Token\Parser
  * @covers \Lcobucci\JWT\Token\Plain

--- a/test/functional/HmacTokenTest.php
+++ b/test/functional/HmacTokenTest.php
@@ -14,6 +14,21 @@ use PHPUnit\Framework\TestCase;
 
 use function assert;
 
+/**
+ * @covers \Lcobucci\JWT\Configuration
+ * @covers \Lcobucci\JWT\Token\Builder
+ * @covers \Lcobucci\JWT\Token\Parser
+ * @covers \Lcobucci\JWT\Token\Plain
+ * @covers \Lcobucci\JWT\Token\DataSet
+ * @covers \Lcobucci\JWT\Token\Signature
+ * @covers \Lcobucci\JWT\Signer\Key
+ * @covers \Lcobucci\JWT\Signer\Hmac
+ * @covers \Lcobucci\JWT\Signer\Hmac\Sha256
+ * @covers \Lcobucci\JWT\Signer\Hmac\Sha512
+ * @covers \Lcobucci\JWT\Validation\Validator
+ * @covers \Lcobucci\JWT\Validation\InvalidToken
+ * @covers \Lcobucci\JWT\Validation\Constraint\SignedWith
+ */
 class HmacTokenTest extends TestCase
 {
     private Configuration $config;
@@ -24,19 +39,7 @@ class HmacTokenTest extends TestCase
         $this->config = Configuration::forSymmetricSigner(new Sha256(), new Key('testing'));
     }
 
-    /**
-     * @test
-     *
-     * @covers \Lcobucci\JWT\Configuration
-     * @covers \Lcobucci\JWT\Token\Builder
-     * @covers \Lcobucci\JWT\Token\Parser
-     * @covers \Lcobucci\JWT\Token\Plain
-     * @covers \Lcobucci\JWT\Token\DataSet
-     * @covers \Lcobucci\JWT\Token\Signature
-     * @covers \Lcobucci\JWT\Signer\Key
-     * @covers \Lcobucci\JWT\Signer\Hmac
-     * @covers \Lcobucci\JWT\Signer\Hmac\Sha256
-     */
+    /** @test */
     public function builderCanGenerateAToken(): Token
     {
         $user    = ['name' => 'testing', 'email' => 'testing@abc.com'];
@@ -60,14 +63,6 @@ class HmacTokenTest extends TestCase
     /**
      * @test
      * @depends builderCanGenerateAToken
-     *
-     * @covers \Lcobucci\JWT\Configuration
-     * @covers \Lcobucci\JWT\Token\Builder
-     * @covers \Lcobucci\JWT\Token\Parser
-     * @covers \Lcobucci\JWT\Token\Plain
-     * @covers \Lcobucci\JWT\Token\DataSet
-     * @covers \Lcobucci\JWT\Token\Signature
-     * @covers \Lcobucci\JWT\Signer\Key
      */
     public function parserCanReadAToken(Token $generated): void
     {
@@ -81,19 +76,6 @@ class HmacTokenTest extends TestCase
     /**
      * @test
      * @depends builderCanGenerateAToken
-     *
-     * @covers \Lcobucci\JWT\Configuration
-     * @covers \Lcobucci\JWT\Token\Builder
-     * @covers \Lcobucci\JWT\Token\Parser
-     * @covers \Lcobucci\JWT\Token\Plain
-     * @covers \Lcobucci\JWT\Token\DataSet
-     * @covers \Lcobucci\JWT\Token\Signature
-     * @covers \Lcobucci\JWT\Signer\Key
-     * @covers \Lcobucci\JWT\Signer\Hmac
-     * @covers \Lcobucci\JWT\Signer\Hmac\Sha256
-     * @covers \Lcobucci\JWT\Validation\Validator
-     * @covers \Lcobucci\JWT\Validation\InvalidToken
-     * @covers \Lcobucci\JWT\Validation\Constraint\SignedWith
      */
     public function signatureAssertionShouldRaiseExceptionWhenKeyIsNotRight(Token $token): void
     {
@@ -109,20 +91,6 @@ class HmacTokenTest extends TestCase
     /**
      * @test
      * @depends builderCanGenerateAToken
-     *
-     * @covers \Lcobucci\JWT\Configuration
-     * @covers \Lcobucci\JWT\Token\Builder
-     * @covers \Lcobucci\JWT\Token\Parser
-     * @covers \Lcobucci\JWT\Token\Plain
-     * @covers \Lcobucci\JWT\Token\DataSet
-     * @covers \Lcobucci\JWT\Token\Signature
-     * @covers \Lcobucci\JWT\Signer\Key
-     * @covers \Lcobucci\JWT\Signer\Hmac
-     * @covers \Lcobucci\JWT\Signer\Hmac\Sha256
-     * @covers \Lcobucci\JWT\Signer\Hmac\Sha512
-     * @covers \Lcobucci\JWT\Validation\Validator
-     * @covers \Lcobucci\JWT\Validation\InvalidToken
-     * @covers \Lcobucci\JWT\Validation\Constraint\SignedWith
      */
     public function signatureAssertionShouldRaiseExceptionWhenAlgorithmIsDifferent(Token $token): void
     {
@@ -138,18 +106,6 @@ class HmacTokenTest extends TestCase
     /**
      * @test
      * @depends builderCanGenerateAToken
-     *
-     * @covers \Lcobucci\JWT\Configuration
-     * @covers \Lcobucci\JWT\Token\Builder
-     * @covers \Lcobucci\JWT\Token\Parser
-     * @covers \Lcobucci\JWT\Token\Plain
-     * @covers \Lcobucci\JWT\Token\DataSet
-     * @covers \Lcobucci\JWT\Token\Signature
-     * @covers \Lcobucci\JWT\Signer\Key
-     * @covers \Lcobucci\JWT\Signer\Hmac
-     * @covers \Lcobucci\JWT\Signer\Hmac\Sha256
-     * @covers \Lcobucci\JWT\Validation\Validator
-     * @covers \Lcobucci\JWT\Validation\Constraint\SignedWith
      */
     public function signatureValidationShouldSucceedWhenKeyIsRight(Token $token): void
     {
@@ -158,21 +114,7 @@ class HmacTokenTest extends TestCase
         self::assertTrue($this->config->getValidator()->validate($token, $constraint));
     }
 
-    /**
-     * @test
-     *
-     * @covers \Lcobucci\JWT\Configuration
-     * @covers \Lcobucci\JWT\Token\Builder
-     * @covers \Lcobucci\JWT\Token\Parser
-     * @covers \Lcobucci\JWT\Token\Plain
-     * @covers \Lcobucci\JWT\Token\DataSet
-     * @covers \Lcobucci\JWT\Token\Signature
-     * @covers \Lcobucci\JWT\Signer\Key
-     * @covers \Lcobucci\JWT\Signer\Hmac
-     * @covers \Lcobucci\JWT\Signer\Hmac\Sha256
-     * @covers \Lcobucci\JWT\Validation\Validator
-     * @covers \Lcobucci\JWT\Validation\Constraint\SignedWith
-     */
+    /** @test */
     public function everythingShouldWorkWhenUsingATokenGeneratedByOtherLibs(): void
     {
         $data = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXUyJ9.eyJoZWxsbyI6IndvcmxkIn0.Rh'

--- a/test/functional/MaliciousTamperingPreventionTest.php
+++ b/test/functional/MaliciousTamperingPreventionTest.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace Lcobucci\JWT\FunctionalTests;
 
-use Lcobucci\Jose\Parsing\Parser;
 use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Encoding\JoseEncoder;
 use Lcobucci\JWT\Keys;
 use Lcobucci\JWT\Signer\Ecdsa\Sha512 as ES512;
 use Lcobucci\JWT\Signer\Hmac\Sha256 as HS512;
@@ -47,6 +47,7 @@ final class MaliciousTamperingPreventionTest extends TestCase
      * @test
      *
      * @covers \Lcobucci\JWT\Configuration
+     * @covers \Lcobucci\JWT\Encoding\JoseEncoder
      * @covers \Lcobucci\JWT\Token\Builder
      * @covers \Lcobucci\JWT\Token\Parser
      * @covers \Lcobucci\JWT\Token\Plain
@@ -105,7 +106,7 @@ final class MaliciousTamperingPreventionTest extends TestCase
 
     private function createMaliciousToken(string $token): string
     {
-        $dec     = new Parser();
+        $dec     = new JoseEncoder();
         $asplode = explode('.', $token);
 
         // The user is lying; we insist that we're using HMAC-SHA512, with the

--- a/test/functional/RsaTokenTest.php
+++ b/test/functional/RsaTokenTest.php
@@ -16,6 +16,22 @@ use PHPUnit\Framework\TestCase;
 
 use function assert;
 
+/**
+ * @covers \Lcobucci\JWT\Configuration
+ * @covers \Lcobucci\JWT\Token\Builder
+ * @covers \Lcobucci\JWT\Token\Parser
+ * @covers \Lcobucci\JWT\Token\Plain
+ * @covers \Lcobucci\JWT\Token\DataSet
+ * @covers \Lcobucci\JWT\Token\Signature
+ * @covers \Lcobucci\JWT\Signer\OpenSSL
+ * @covers \Lcobucci\JWT\Signer\Key
+ * @covers \Lcobucci\JWT\Signer\Rsa
+ * @covers \Lcobucci\JWT\Signer\Rsa\Sha256
+ * @covers \Lcobucci\JWT\Signer\Rsa\Sha512
+ * @covers \Lcobucci\JWT\Validation\Validator
+ * @covers \Lcobucci\JWT\Validation\InvalidToken
+ * @covers \Lcobucci\JWT\Validation\Constraint\SignedWith
+ */
 class RsaTokenTest extends TestCase
 {
     use Keys;
@@ -32,20 +48,7 @@ class RsaTokenTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     *
-     * @covers \Lcobucci\JWT\Configuration
-     * @covers \Lcobucci\JWT\Token\Builder
-     * @covers \Lcobucci\JWT\Token\Parser
-     * @covers \Lcobucci\JWT\Token\Plain
-     * @covers \Lcobucci\JWT\Token\DataSet
-     * @covers \Lcobucci\JWT\Token\Signature
-     * @covers \Lcobucci\JWT\Signer\Key
-     * @covers \Lcobucci\JWT\Signer\OpenSSL
-     * @covers \Lcobucci\JWT\Signer\Rsa
-     * @covers \Lcobucci\JWT\Signer\Rsa\Sha256
-     */
+    /** @test */
     public function builderShouldRaiseExceptionWhenKeyIsInvalid(): void
     {
         $builder = $this->config->createBuilder();
@@ -60,20 +63,7 @@ class RsaTokenTest extends TestCase
                 ->getToken($this->config->getSigner(), new Key('testing'));
     }
 
-    /**
-     * @test
-     *
-     * @covers \Lcobucci\JWT\Configuration
-     * @covers \Lcobucci\JWT\Token\Builder
-     * @covers \Lcobucci\JWT\Token\Parser
-     * @covers \Lcobucci\JWT\Token\Plain
-     * @covers \Lcobucci\JWT\Token\DataSet
-     * @covers \Lcobucci\JWT\Token\Signature
-     * @covers \Lcobucci\JWT\Signer\Key
-     * @covers \Lcobucci\JWT\Signer\OpenSSL
-     * @covers \Lcobucci\JWT\Signer\Rsa
-     * @covers \Lcobucci\JWT\Signer\Rsa\Sha256
-     */
+    /** @test */
     public function builderShouldRaiseExceptionWhenKeyIsNotRsaCompatible(): void
     {
         $builder = $this->config->createBuilder();
@@ -88,20 +78,7 @@ class RsaTokenTest extends TestCase
                 ->getToken($this->config->getSigner(), static::$ecdsaKeys['private']);
     }
 
-    /**
-     * @test
-     *
-     * @covers \Lcobucci\JWT\Configuration
-     * @covers \Lcobucci\JWT\Token\Builder
-     * @covers \Lcobucci\JWT\Token\Parser
-     * @covers \Lcobucci\JWT\Token\Plain
-     * @covers \Lcobucci\JWT\Token\DataSet
-     * @covers \Lcobucci\JWT\Token\Signature
-     * @covers \Lcobucci\JWT\Signer\Key
-     * @covers \Lcobucci\JWT\Signer\OpenSSL
-     * @covers \Lcobucci\JWT\Signer\Rsa
-     * @covers \Lcobucci\JWT\Signer\Rsa\Sha256
-     */
+    /** @test */
     public function builderCanGenerateAToken(): Token
     {
         $user    = ['name' => 'testing', 'email' => 'testing@abc.com'];
@@ -125,13 +102,6 @@ class RsaTokenTest extends TestCase
     /**
      * @test
      * @depends builderCanGenerateAToken
-     *
-     * @covers \Lcobucci\JWT\Configuration
-     * @covers \Lcobucci\JWT\Token\Builder
-     * @covers \Lcobucci\JWT\Token\Parser
-     * @covers \Lcobucci\JWT\Token\Plain
-     * @covers \Lcobucci\JWT\Token\DataSet
-     * @covers \Lcobucci\JWT\Token\Signature
      */
     public function parserCanReadAToken(Token $generated): void
     {
@@ -145,20 +115,6 @@ class RsaTokenTest extends TestCase
     /**
      * @test
      * @depends builderCanGenerateAToken
-     *
-     * @covers \Lcobucci\JWT\Configuration
-     * @covers \Lcobucci\JWT\Token\Builder
-     * @covers \Lcobucci\JWT\Token\Parser
-     * @covers \Lcobucci\JWT\Token\Plain
-     * @covers \Lcobucci\JWT\Token\DataSet
-     * @covers \Lcobucci\JWT\Token\Signature
-     * @covers \Lcobucci\JWT\Signer\Key
-     * @covers \Lcobucci\JWT\Signer\OpenSSL
-     * @covers \Lcobucci\JWT\Signer\Rsa
-     * @covers \Lcobucci\JWT\Signer\Rsa\Sha256
-     * @covers \Lcobucci\JWT\Validation\Validator
-     * @covers \Lcobucci\JWT\Validation\Constraint\SignedWith
-     * @covers \Lcobucci\JWT\Validation\InvalidToken
      */
     public function signatureAssertionShouldRaiseExceptionWhenKeyIsNotRight(Token $token): void
     {
@@ -174,21 +130,6 @@ class RsaTokenTest extends TestCase
     /**
      * @test
      * @depends builderCanGenerateAToken
-     *
-     * @covers \Lcobucci\JWT\Configuration
-     * @covers \Lcobucci\JWT\Token\Builder
-     * @covers \Lcobucci\JWT\Token\Parser
-     * @covers \Lcobucci\JWT\Token\Plain
-     * @covers \Lcobucci\JWT\Token\DataSet
-     * @covers \Lcobucci\JWT\Token\Signature
-     * @covers \Lcobucci\JWT\Signer\OpenSSL
-     * @covers \Lcobucci\JWT\Signer\Key
-     * @covers \Lcobucci\JWT\Signer\Rsa
-     * @covers \Lcobucci\JWT\Signer\Rsa\Sha256
-     * @covers \Lcobucci\JWT\Signer\Rsa\Sha512
-     * @covers \Lcobucci\JWT\Validation\Validator
-     * @covers \Lcobucci\JWT\Validation\InvalidToken
-     * @covers \Lcobucci\JWT\Validation\Constraint\SignedWith
      */
     public function signatureAssertionShouldRaiseExceptionWhenAlgorithmIsDifferent(Token $token): void
     {
@@ -204,19 +145,6 @@ class RsaTokenTest extends TestCase
     /**
      * @test
      * @depends builderCanGenerateAToken
-     *
-     * @covers \Lcobucci\JWT\Configuration
-     * @covers \Lcobucci\JWT\Token\Builder
-     * @covers \Lcobucci\JWT\Token\Parser
-     * @covers \Lcobucci\JWT\Token\Plain
-     * @covers \Lcobucci\JWT\Token\DataSet
-     * @covers \Lcobucci\JWT\Token\Signature
-     * @covers \Lcobucci\JWT\Signer\Key
-     * @covers \Lcobucci\JWT\Signer\OpenSSL
-     * @covers \Lcobucci\JWT\Signer\Rsa
-     * @covers \Lcobucci\JWT\Signer\Rsa\Sha256
-     * @covers \Lcobucci\JWT\Validation\Validator
-     * @covers \Lcobucci\JWT\Validation\Constraint\SignedWith
      */
     public function signatureAssertionShouldRaiseExceptionWhenKeyIsNotRsaCompatible(Token $token): void
     {
@@ -235,19 +163,6 @@ class RsaTokenTest extends TestCase
     /**
      * @test
      * @depends builderCanGenerateAToken
-     *
-     * @covers \Lcobucci\JWT\Configuration
-     * @covers \Lcobucci\JWT\Token\Builder
-     * @covers \Lcobucci\JWT\Token\Parser
-     * @covers \Lcobucci\JWT\Token\Plain
-     * @covers \Lcobucci\JWT\Token\DataSet
-     * @covers \Lcobucci\JWT\Token\Signature
-     * @covers \Lcobucci\JWT\Signer\Key
-     * @covers \Lcobucci\JWT\Signer\OpenSSL
-     * @covers \Lcobucci\JWT\Signer\Rsa
-     * @covers \Lcobucci\JWT\Signer\Rsa\Sha256
-     * @covers \Lcobucci\JWT\Validation\Validator
-     * @covers \Lcobucci\JWT\Validation\Constraint\SignedWith
      */
     public function signatureValidationShouldSucceedWhenKeyIsRight(Token $token): void
     {
@@ -256,22 +171,7 @@ class RsaTokenTest extends TestCase
         self::assertTrue($this->config->getValidator()->validate($token, $constraint));
     }
 
-    /**
-     * @test
-     *
-     * @covers \Lcobucci\JWT\Configuration
-     * @covers \Lcobucci\JWT\Token\Builder
-     * @covers \Lcobucci\JWT\Token\Parser
-     * @covers \Lcobucci\JWT\Token\Plain
-     * @covers \Lcobucci\JWT\Token\DataSet
-     * @covers \Lcobucci\JWT\Token\Signature
-     * @covers \Lcobucci\JWT\Signer\Key
-     * @covers \Lcobucci\JWT\Signer\OpenSSL
-     * @covers \Lcobucci\JWT\Signer\Rsa
-     * @covers \Lcobucci\JWT\Signer\Rsa\Sha256
-     * @covers \Lcobucci\JWT\Validation\Validator
-     * @covers \Lcobucci\JWT\Validation\Constraint\SignedWith
-     */
+    /** @test */
     public function everythingShouldWorkWhenUsingATokenGeneratedByOtherLibs(): void
     {
         $data = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXUyJ9.eyJoZWxsbyI6IndvcmxkIn0.s'

--- a/test/functional/RsaTokenTest.php
+++ b/test/functional/RsaTokenTest.php
@@ -18,6 +18,7 @@ use function assert;
 
 /**
  * @covers \Lcobucci\JWT\Configuration
+ * @covers \Lcobucci\JWT\Encoding\JoseEncoder
  * @covers \Lcobucci\JWT\Token\Builder
  * @covers \Lcobucci\JWT\Token\Parser
  * @covers \Lcobucci\JWT\Token\Plain

--- a/test/functional/UnsignedTokenTest.php
+++ b/test/functional/UnsignedTokenTest.php
@@ -18,6 +18,22 @@ use PHPUnit\Framework\TestCase;
 
 use function assert;
 
+/**
+ * @covers \Lcobucci\JWT\Configuration
+ * @covers \Lcobucci\JWT\Token\Builder
+ * @covers \Lcobucci\JWT\Token\Parser
+ * @covers \Lcobucci\JWT\Token\Plain
+ * @covers \Lcobucci\JWT\Token\DataSet
+ * @covers \Lcobucci\JWT\Token\Signature
+ * @covers \Lcobucci\JWT\Signer\None
+ * @covers \Lcobucci\JWT\Signer\Key
+ * @covers \Lcobucci\JWT\Validation\InvalidToken
+ * @covers \Lcobucci\JWT\Validation\Validator
+ * @covers \Lcobucci\JWT\Validation\Constraint\IssuedBy
+ * @covers \Lcobucci\JWT\Validation\Constraint\PermittedFor
+ * @covers \Lcobucci\JWT\Validation\Constraint\IdentifiedBy
+ * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt
+ */
 class UnsignedTokenTest extends TestCase
 {
     public const CURRENT_TIME = 100000;
@@ -30,18 +46,7 @@ class UnsignedTokenTest extends TestCase
         $this->config = Configuration::forUnsecuredSigner();
     }
 
-    /**
-     * @test
-     *
-     * @covers \Lcobucci\JWT\Configuration
-     * @covers \Lcobucci\JWT\Token\Builder
-     * @covers \Lcobucci\JWT\Token\Parser
-     * @covers \Lcobucci\JWT\Token\Plain
-     * @covers \Lcobucci\JWT\Token\DataSet
-     * @covers \Lcobucci\JWT\Token\Signature
-     * @covers \Lcobucci\JWT\Signer\None
-     * @covers \Lcobucci\JWT\Signer\Key
-     */
+    /** @test */
     public function builderCanGenerateAToken(): Token
     {
         $user    = ['name' => 'testing', 'email' => 'testing@abc.com'];
@@ -68,15 +73,6 @@ class UnsignedTokenTest extends TestCase
     /**
      * @test
      * @depends builderCanGenerateAToken
-     *
-     * @covers \Lcobucci\JWT\Configuration
-     * @covers \Lcobucci\JWT\Token\Builder
-     * @covers \Lcobucci\JWT\Token\Parser
-     * @covers \Lcobucci\JWT\Token\Plain
-     * @covers \Lcobucci\JWT\Token\DataSet
-     * @covers \Lcobucci\JWT\Token\Signature
-     * @covers \Lcobucci\JWT\Signer\None
-     * @covers \Lcobucci\JWT\Signer\Key
      */
     public function parserCanReadAToken(Token $generated): void
     {
@@ -90,20 +86,6 @@ class UnsignedTokenTest extends TestCase
     /**
      * @test
      * @depends builderCanGenerateAToken
-     *
-     * @covers \Lcobucci\JWT\Configuration
-     * @covers \Lcobucci\JWT\Token\Builder
-     * @covers \Lcobucci\JWT\Token\Parser
-     * @covers \Lcobucci\JWT\Token\Plain
-     * @covers \Lcobucci\JWT\Token\DataSet
-     * @covers \Lcobucci\JWT\Token\Signature
-     * @covers \Lcobucci\JWT\Signer\None
-     * @covers \Lcobucci\JWT\Signer\Key
-     * @covers \Lcobucci\JWT\Validation\Validator
-     * @covers \Lcobucci\JWT\Validation\Constraint\IssuedBy
-     * @covers \Lcobucci\JWT\Validation\Constraint\PermittedFor
-     * @covers \Lcobucci\JWT\Validation\Constraint\IdentifiedBy
-     * @covers \Lcobucci\JWT\Validation\Constraint\ValidAt
      */
     public function tokenValidationShouldPassWhenEverythingIsFine(Token $generated): void
     {
@@ -122,16 +104,6 @@ class UnsignedTokenTest extends TestCase
     /**
      * @test
      * @depends builderCanGenerateAToken
-     *
-     * @covers \Lcobucci\JWT\Configuration
-     * @covers \Lcobucci\JWT\Token\Builder
-     * @covers \Lcobucci\JWT\Token\Parser
-     * @covers \Lcobucci\JWT\Token\Plain
-     * @covers \Lcobucci\JWT\Token\DataSet
-     * @covers \Lcobucci\JWT\Token\Signature
-     * @covers \Lcobucci\JWT\Signer\None
-     * @covers \Lcobucci\JWT\Signer\Key
-     * @covers \Lcobucci\JWT\Validation\Validator
      */
     public function tokenValidationShouldAllowCustomConstraint(Token $generated): void
     {
@@ -141,19 +113,6 @@ class UnsignedTokenTest extends TestCase
     /**
      * @test
      * @depends builderCanGenerateAToken
-     *
-     * @covers \Lcobucci\JWT\Configuration
-     * @covers \Lcobucci\JWT\Token\Builder
-     * @covers \Lcobucci\JWT\Token\Parser
-     * @covers \Lcobucci\JWT\Token\Plain
-     * @covers \Lcobucci\JWT\Token\DataSet
-     * @covers \Lcobucci\JWT\Token\Signature
-     * @covers \Lcobucci\JWT\Signer\None
-     * @covers \Lcobucci\JWT\Signer\Key
-     * @covers \Lcobucci\JWT\Validation\Validator
-     * @covers \Lcobucci\JWT\Validation\InvalidToken
-     * @covers \Lcobucci\JWT\Validation\Constraint\IssuedBy
-     * @covers \Lcobucci\JWT\Validation\Constraint\IdentifiedBy
      */
     public function tokenAssertionShouldRaiseExceptionWhenOneOfTheConstraintsFails(Token $generated): void
     {

--- a/test/functional/UnsignedTokenTest.php
+++ b/test/functional/UnsignedTokenTest.php
@@ -20,6 +20,7 @@ use function assert;
 
 /**
  * @covers \Lcobucci\JWT\Configuration
+ * @covers \Lcobucci\JWT\Encoding\JoseEncoder
  * @covers \Lcobucci\JWT\Token\Builder
  * @covers \Lcobucci\JWT\Token\Parser
  * @covers \Lcobucci\JWT\Token\Plain

--- a/test/performance/Hmac/HmacBench.php
+++ b/test/performance/Hmac/HmacBench.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Lcobucci\JWT\Hmac;
 
-use Lcobucci\Jose\Parsing\Parser;
+use Lcobucci\JWT\Encoding\JoseEncoder;
 use Lcobucci\JWT\Signer\Key;
 use Lcobucci\JWT\SignerBench;
 use PhpBench\Benchmark\Metadata\Annotations\Groups;
@@ -25,7 +25,7 @@ abstract class HmacBench extends SignerBench
 
     private function createKey(): Key
     {
-        $decoder = new Parser();
+        $decoder = new JoseEncoder();
 
         return new Key($decoder->base64UrlDecode(self::ENCODED_KEY));
     }

--- a/test/unit/ConfigurationTest.php
+++ b/test/unit/ConfigurationTest.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Lcobucci\JWT;
 
-use Lcobucci\Jose\Parsing;
 use Lcobucci\JWT\Signer\Key;
 use Lcobucci\JWT\Signer\None;
 use Lcobucci\JWT\Token\Builder as BuilderImpl;
@@ -26,11 +25,11 @@ final class ConfigurationTest extends TestCase
     /** @var Signer&MockObject */
     private Signer $signer;
 
-    /** @var Parsing\Encoder&MockObject */
-    private Parsing\Encoder $encoder;
+    /** @var Encoder&MockObject */
+    private Encoder $encoder;
 
-    /** @var Parsing\Decoder&MockObject */
-    private Parsing\Decoder $decoder;
+    /** @var Decoder&MockObject */
+    private Decoder $decoder;
 
     /** @var Validator&MockObject */
     private Validator $validator;
@@ -42,8 +41,8 @@ final class ConfigurationTest extends TestCase
     public function createDependencies(): void
     {
         $this->signer                = $this->createMock(Signer::class);
-        $this->encoder               = $this->createMock(Parsing\Encoder::class);
-        $this->decoder               = $this->createMock(Parsing\Decoder::class);
+        $this->encoder               = $this->createMock(Encoder::class);
+        $this->decoder               = $this->createMock(Decoder::class);
         $this->parser                = $this->createMock(Parser::class);
         $this->validator             = $this->createMock(Validator::class);
         $this->validationConstraints = $this->createMock(Constraint::class);

--- a/test/unit/Encoding/JoseEncoderTest.php
+++ b/test/unit/Encoding/JoseEncoderTest.php
@@ -1,0 +1,188 @@
+<?php
+declare(strict_types=1);
+
+namespace Lcobucci\JWT\Encoding;
+
+use PHPUnit\Framework\TestCase;
+
+use function assert;
+use function base64_decode;
+use function is_string;
+
+/**
+ * @covers \Lcobucci\JWT\Encoding\CannotDecodeContent
+ * @covers \Lcobucci\JWT\Encoding\CannotEncodeContent
+ * @coversDefaultClass \Lcobucci\JWT\Encoding\JoseEncoder
+ */
+final class JoseEncoderTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @covers ::jsonEncode
+     */
+    public function jsonEncodeMustReturnAJSONString(): void
+    {
+        $encoder = new JoseEncoder();
+
+        self::assertSame('{"test":"test"}', $encoder->jsonEncode(['test' => 'test']));
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::jsonEncode
+     */
+    public function jsonEncodeShouldNotEscapeUnicode(): void
+    {
+        $encoder = new JoseEncoder();
+
+        self::assertSame('"汉语"', $encoder->jsonEncode('汉语'));
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::jsonEncode
+     */
+    public function jsonEncodeShouldNotEscapeSlashes(): void
+    {
+        $encoder = new JoseEncoder();
+
+        self::assertSame('"http://google.com"', $encoder->jsonEncode('http://google.com'));
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::jsonEncode
+     */
+    public function jsonEncodeMustRaiseExceptionWhenAnErrorHasOccurred(): void
+    {
+        $encoder = new JoseEncoder();
+
+        $this->expectException(CannotEncodeContent::class);
+        $this->expectExceptionCode(0);
+        $this->expectExceptionMessage('Error while encoding to JSON');
+
+        $encoder->jsonEncode("\xB1\x31");
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::jsonDecode
+     */
+    public function jsonDecodeMustReturnTheDecodedData(): void
+    {
+        $decoder = new JoseEncoder();
+
+        self::assertSame(
+            ['test' => ['test' => []]],
+            $decoder->jsonDecode('{"test":{"test":{}}}')
+        );
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::jsonDecode
+     */
+    public function jsonDecodeMustRaiseExceptionWhenAnErrorHasOccurred(): void
+    {
+        $decoder = new JoseEncoder();
+
+        $this->expectException(CannotDecodeContent::class);
+        $this->expectExceptionCode(0);
+        $this->expectExceptionMessage('Error while decoding from JSON');
+
+        $decoder->jsonDecode('{"test":\'test\'}');
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::base64UrlEncode
+     */
+    public function base64UrlEncodeMustReturnAUrlSafeBase64(): void
+    {
+        $data = base64_decode('0MB2wKB+L3yvIdzeggmJ+5WOSLaRLTUPXbpzqUe0yuo=', true);
+        assert(is_string($data));
+
+        $encoder = new JoseEncoder();
+        self::assertSame('0MB2wKB-L3yvIdzeggmJ-5WOSLaRLTUPXbpzqUe0yuo', $encoder->base64UrlEncode($data));
+    }
+
+    /**
+     * @link https://tools.ietf.org/html/rfc7520#section-4
+     *
+     * @test
+     *
+     * @covers ::base64UrlEncode
+     */
+    public function base64UrlEncodeMustEncodeBilboMessageProperly(): void
+    {
+        $message = 'It’s a dangerous business, Frodo, going out your door. You step '
+                   . "onto the road, and if you don't keep your feet, there’s no knowing "
+                   . 'where you might be swept off to.';
+
+        $expected = 'SXTigJlzIGEgZGFuZ2Vyb3VzIGJ1c2luZXNzLCBGcm9kbywgZ29pbmcgb3V0IH'
+                    . 'lvdXIgZG9vci4gWW91IHN0ZXAgb250byB0aGUgcm9hZCwgYW5kIGlmIHlvdSBk'
+                    . 'b24ndCBrZWVwIHlvdXIgZmVldCwgdGhlcmXigJlzIG5vIGtub3dpbmcgd2hlcm'
+                    . 'UgeW91IG1pZ2h0IGJlIHN3ZXB0IG9mZiB0by4';
+
+        $encoder = new JoseEncoder();
+        self::assertSame($expected, $encoder->base64UrlEncode($message));
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::base64UrlDecode
+     */
+    public function base64UrlDecodeMustRaiseExceptionWhenInvalidBase64CharsAreUsed(): void
+    {
+        $decoder = new JoseEncoder();
+
+        $this->expectException(CannotDecodeContent::class);
+        $this->expectExceptionCode(0);
+        $this->expectExceptionMessage('Error while decoding from Base64Url, invalid base64 characters detected');
+
+        $decoder->base64UrlDecode('áááááá');
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::base64UrlDecode
+     */
+    public function base64UrlDecodeMustReturnTheRightData(): void
+    {
+        $data = base64_decode('0MB2wKB+L3yvIdzeggmJ+5WOSLaRLTUPXbpzqUe0yuo=', true);
+
+        $decoder = new JoseEncoder();
+        self::assertSame($data, $decoder->base64UrlDecode('0MB2wKB-L3yvIdzeggmJ-5WOSLaRLTUPXbpzqUe0yuo'));
+    }
+
+    /**
+     * @link https://tools.ietf.org/html/rfc7520#section-4
+     *
+     * @test
+     *
+     * @covers ::base64UrlDecode
+     */
+    public function base64UrlDecodeMustDecodeBilboMessageProperly(): void
+    {
+        $message = 'SXTigJlzIGEgZGFuZ2Vyb3VzIGJ1c2luZXNzLCBGcm9kbywgZ29pbmcgb3V0IH'
+                   . 'lvdXIgZG9vci4gWW91IHN0ZXAgb250byB0aGUgcm9hZCwgYW5kIGlmIHlvdSBk'
+                   . 'b24ndCBrZWVwIHlvdXIgZmVldCwgdGhlcmXigJlzIG5vIGtub3dpbmcgd2hlcm'
+                   . 'UgeW91IG1pZ2h0IGJlIHN3ZXB0IG9mZiB0by4';
+
+        $expected = 'It’s a dangerous business, Frodo, going out your door. You step '
+                    . "onto the road, and if you don't keep your feet, there’s no knowing "
+                    . 'where you might be swept off to.';
+
+        $encoder = new JoseEncoder();
+        self::assertSame($expected, $encoder->base64UrlDecode($message));
+    }
+}

--- a/test/unit/Token/BuilderTest.php
+++ b/test/unit/Token/BuilderTest.php
@@ -5,7 +5,7 @@ namespace Lcobucci\JWT\Token;
 
 use DateTimeImmutable;
 use InvalidArgumentException;
-use Lcobucci\Jose\Parsing\Encoder;
+use Lcobucci\JWT\Encoder;
 use Lcobucci\JWT\Signer;
 use Lcobucci\JWT\Signer\Key;
 use PHPUnit\Framework\MockObject\MockObject;

--- a/test/unit/Token/ParserTest.php
+++ b/test/unit/Token/ParserTest.php
@@ -5,7 +5,7 @@ namespace Lcobucci\JWT\Token;
 
 use DateTimeImmutable;
 use InvalidArgumentException;
-use Lcobucci\Jose\Parsing\Decoder;
+use Lcobucci\JWT\Decoder;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;


### PR DESCRIPTION
We extracted this thinking about supporting many other packages for the JOSE standards. The reality, though, was that we created more work without benefiting from the separation.