### PR TITLE
Rename getters

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -125,10 +125,10 @@ Once you've made all the necessary configuration you can pass the configuration 
 
 These are the available getters:
 
-* `Lcobucci\JWT\Configuration#createBuilder()`: retrieves the token builder (always creating a new instance)
-* `Lcobucci\JWT\Configuration#getParser()`: retrieves the token parser
-* `Lcobucci\JWT\Configuration#getSigner()`: retrieves the signer
-* `Lcobucci\JWT\Configuration#getSigningKey()`: retrieves the key for signature creation
-* `Lcobucci\JWT\Configuration#getVerificationKey()`: retrieves the key for signature verification
-* `Lcobucci\JWT\Configuration#getValidator()`: retrieves the token validator
-* `Lcobucci\JWT\Configuration#getValidationConstraints()`: retrieves the default set of validation constraints
+* `Lcobucci\JWT\Configuration#builder()`: retrieves the token builder (always creating a new instance)
+* `Lcobucci\JWT\Configuration#parser()`: retrieves the token parser
+* `Lcobucci\JWT\Configuration#signer()`: retrieves the signer
+* `Lcobucci\JWT\Configuration#signingKey()`: retrieves the key for signature creation
+* `Lcobucci\JWT\Configuration#verificationKey()`: retrieves the key for signature verification
+* `Lcobucci\JWT\Configuration#validator()`: retrieves the token validator
+* `Lcobucci\JWT\Configuration#validationConstraints()`: retrieves the default set of validation constraints

--- a/docs/extending-the-library.md
+++ b/docs/extending-the-library.md
@@ -74,7 +74,7 @@ final class UnixTimestampDates implements ClaimsFormatter
 $config = $container->get(Configuration::class);
 assert($config instanceof Configuration);
 
-$config->createBuilder(new UnixTimestampDates());
+$config->builder(new UnixTimestampDates());
 ```
 
 The class `Lcobucci\JWT\Encoding\ChainedFormatter` allows for users to combine multiple formatters. 

--- a/docs/issuing-tokens.md
+++ b/docs/issuing-tokens.md
@@ -13,7 +13,7 @@ $config = $container->get(Configuration::class);
 assert($config instanceof Configuration);
 
 $now   = new DateTimeImmutable();
-$token = $config->createBuilder()
+$token = $config->builder()
                 // Configures the issuer (iss claim)
                 ->issuedBy('http://example.com')
                 // Configures the audience (aud claim)
@@ -31,7 +31,7 @@ $token = $config->createBuilder()
                 // Configures a new header, called "foo"
                 ->withHeader('foo', 'bar')
                 // Builds a new token
-                ->getToken($config->getSigner(), $config->getSigningKey());
+                ->getToken($config->signer(), $config->signingKey());
 ```
 
 Once you've created a token, you're able to retrieve its data and convert it to its string representation:
@@ -42,11 +42,11 @@ use Lcobucci\JWT\Configuration;
 $config = $container->get(Configuration::class);
 assert($config instanceof Configuration);
 
-$token = $config->createBuilder()
+$token = $config->builder()
                 ->issuedBy('http://example.com')
                 ->withClaim('uid', 1)
                 ->withHeader('foo', 'bar')
-                ->getToken($config->getSigner(), $config->getSigningKey());
+                ->getToken($config->signer(), $config->signingKey());
 
 $token->headers(); // Retrieves the token headers
 $token->claims(); // Retrieves the token claims

--- a/docs/parsing-tokens.md
+++ b/docs/parsing-tokens.md
@@ -13,7 +13,7 @@ use Lcobucci\JWT\Token\Plain;
 $config = $container->get(Configuration::class);
 assert($config instanceof Configuration);
 
-$token = $config->getParser()->parse(
+$token = $config->parser()->parse(
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.'
     . 'eyJzdWIiOiIxMjM0NTY3ODkwIn0.'
     . '2gSBz9EOsQRN9I-3iSxJoFt7NtgV6Rm0IL6a8CAwl3Q'

--- a/docs/validating-tokens.md
+++ b/docs/validating-tokens.md
@@ -21,13 +21,13 @@ use Lcobucci\JWT\Validation\RequiredConstraintsViolated;
 $token = $container->get(Configuration::class);
 assert($config instanceof Configuration);
 
-$token = $config->getParser()->parse('...');
+$token = $config->parser()->parse('...');
 assert($token instanceof Plain);
 
-$constraints = $config->getValidationConstraints();
+$constraints = $config->validationConstraints();
 
 try {
-    $config->getValidator()->assert($token, ...$constraints);
+    $config->validator()->assert($token, ...$constraints);
 } catch (RequiredConstraintsViolated $e) {
     // list of constraints violation exceptions:
     var_dump($e->violations());
@@ -48,12 +48,12 @@ use Lcobucci\JWT\Token\Plain;
 $token = $container->get(Configuration::class);
 assert($config instanceof Configuration);
 
-$token = $config->getParser()->parse('...');
+$token = $config->parser()->parse('...');
 assert($token instanceof Plain);
 
-$constraints = $config->getValidationConstraints();
+$constraints = $config->validationConstraints();
 
-if (! $config->getValidator()->validate($token, ...$constraints)) {
+if (! $config->validator()->validate($token, ...$constraints)) {
    throw new RuntimeException('No way!');
 }
 ```

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -101,12 +101,12 @@ final class Configuration
         $this->builderFactory = Closure::fromCallable($builderFactory);
     }
 
-    public function createBuilder(?ClaimsFormatter $claimFormatter = null): Builder
+    public function builder(?ClaimsFormatter $claimFormatter = null): Builder
     {
         return ($this->builderFactory)($claimFormatter ?? ChainedFormatter::default());
     }
 
-    public function getParser(): Parser
+    public function parser(): Parser
     {
         return $this->parser;
     }
@@ -116,22 +116,22 @@ final class Configuration
         $this->parser = $parser;
     }
 
-    public function getSigner(): Signer
+    public function signer(): Signer
     {
         return $this->signer;
     }
 
-    public function getSigningKey(): Key
+    public function signingKey(): Key
     {
         return $this->signingKey;
     }
 
-    public function getVerificationKey(): Key
+    public function verificationKey(): Key
     {
         return $this->verificationKey;
     }
 
-    public function getValidator(): Validator
+    public function validator(): Validator
     {
         return $this->validator;
     }
@@ -142,7 +142,7 @@ final class Configuration
     }
 
     /** @return Constraint[] */
-    public function getValidationConstraints(): array
+    public function validationConstraints(): array
     {
         return $this->validationConstraints;
     }

--- a/src/Signer.php
+++ b/src/Signer.php
@@ -13,7 +13,7 @@ interface Signer
     /**
      * Returns the algorithm id
      */
-    public function getAlgorithmId(): string;
+    public function algorithmId(): string;
 
     /**
      * Creates a hash for the given payload

--- a/src/Signer/Ecdsa.php
+++ b/src/Signer/Ecdsa.php
@@ -26,20 +26,20 @@ abstract class Ecdsa extends OpenSSL
     {
         return $this->converter->fromAsn1(
             $this->createSignature($key->contents(), $key->passphrase(), $payload),
-            $this->getKeyLength()
+            $this->keyLength()
         );
     }
 
     final public function verify(string $expected, string $payload, Key $key): bool
     {
         return $this->verifySignature(
-            $this->converter->toAsn1($expected, $this->getKeyLength()),
+            $this->converter->toAsn1($expected, $this->keyLength()),
             $payload,
             $key->contents()
         );
     }
 
-    final public function getKeyType(): int
+    final public function keyType(): int
     {
         return OPENSSL_KEYTYPE_EC;
     }
@@ -49,5 +49,5 @@ abstract class Ecdsa extends OpenSSL
      *
      * @internal
      */
-    abstract public function getKeyLength(): int;
+    abstract public function keyLength(): int;
 }

--- a/src/Signer/Ecdsa/Sha256.php
+++ b/src/Signer/Ecdsa/Sha256.php
@@ -9,7 +9,7 @@ use const OPENSSL_ALGO_SHA256;
 
 final class Sha256 extends Ecdsa
 {
-    public function getAlgorithmId(): string
+    public function algorithmId(): string
     {
         return 'ES256';
     }

--- a/src/Signer/Ecdsa/Sha256.php
+++ b/src/Signer/Ecdsa/Sha256.php
@@ -14,12 +14,12 @@ final class Sha256 extends Ecdsa
         return 'ES256';
     }
 
-    public function getAlgorithm(): int
+    public function algorithm(): int
     {
         return OPENSSL_ALGO_SHA256;
     }
 
-    public function getKeyLength(): int
+    public function keyLength(): int
     {
         return 64;
     }

--- a/src/Signer/Ecdsa/Sha384.php
+++ b/src/Signer/Ecdsa/Sha384.php
@@ -14,12 +14,12 @@ final class Sha384 extends Ecdsa
         return 'ES384';
     }
 
-    public function getAlgorithm(): int
+    public function algorithm(): int
     {
         return OPENSSL_ALGO_SHA384;
     }
 
-    public function getKeyLength(): int
+    public function keyLength(): int
     {
         return 96;
     }

--- a/src/Signer/Ecdsa/Sha384.php
+++ b/src/Signer/Ecdsa/Sha384.php
@@ -9,7 +9,7 @@ use const OPENSSL_ALGO_SHA384;
 
 final class Sha384 extends Ecdsa
 {
-    public function getAlgorithmId(): string
+    public function algorithmId(): string
     {
         return 'ES384';
     }

--- a/src/Signer/Ecdsa/Sha512.php
+++ b/src/Signer/Ecdsa/Sha512.php
@@ -9,7 +9,7 @@ use const OPENSSL_ALGO_SHA512;
 
 final class Sha512 extends Ecdsa
 {
-    public function getAlgorithmId(): string
+    public function algorithmId(): string
     {
         return 'ES512';
     }

--- a/src/Signer/Ecdsa/Sha512.php
+++ b/src/Signer/Ecdsa/Sha512.php
@@ -14,12 +14,12 @@ final class Sha512 extends Ecdsa
         return 'ES512';
     }
 
-    public function getAlgorithm(): int
+    public function algorithm(): int
     {
         return OPENSSL_ALGO_SHA512;
     }
 
-    public function getKeyLength(): int
+    public function keyLength(): int
     {
         return 132;
     }

--- a/src/Signer/Hmac.php
+++ b/src/Signer/Hmac.php
@@ -12,7 +12,7 @@ abstract class Hmac implements Signer
 {
     final public function sign(string $payload, Key $key): string
     {
-        return hash_hmac($this->getAlgorithm(), $payload, $key->contents(), true);
+        return hash_hmac($this->algorithm(), $payload, $key->contents(), true);
     }
 
     final public function verify(string $expected, string $payload, Key $key): bool
@@ -20,5 +20,5 @@ abstract class Hmac implements Signer
         return hash_equals($expected, $this->sign($payload, $key));
     }
 
-    abstract public function getAlgorithm(): string;
+    abstract public function algorithm(): string;
 }

--- a/src/Signer/Hmac/Sha256.php
+++ b/src/Signer/Hmac/Sha256.php
@@ -7,7 +7,7 @@ use Lcobucci\JWT\Signer\Hmac;
 
 final class Sha256 extends Hmac
 {
-    public function getAlgorithmId(): string
+    public function algorithmId(): string
     {
         return 'HS256';
     }

--- a/src/Signer/Hmac/Sha256.php
+++ b/src/Signer/Hmac/Sha256.php
@@ -12,7 +12,7 @@ final class Sha256 extends Hmac
         return 'HS256';
     }
 
-    public function getAlgorithm(): string
+    public function algorithm(): string
     {
         return 'sha256';
     }

--- a/src/Signer/Hmac/Sha384.php
+++ b/src/Signer/Hmac/Sha384.php
@@ -7,7 +7,7 @@ use Lcobucci\JWT\Signer\Hmac;
 
 final class Sha384 extends Hmac
 {
-    public function getAlgorithmId(): string
+    public function algorithmId(): string
     {
         return 'HS384';
     }

--- a/src/Signer/Hmac/Sha384.php
+++ b/src/Signer/Hmac/Sha384.php
@@ -12,7 +12,7 @@ final class Sha384 extends Hmac
         return 'HS384';
     }
 
-    public function getAlgorithm(): string
+    public function algorithm(): string
     {
         return 'sha384';
     }

--- a/src/Signer/Hmac/Sha512.php
+++ b/src/Signer/Hmac/Sha512.php
@@ -12,7 +12,7 @@ final class Sha512 extends Hmac
         return 'HS512';
     }
 
-    public function getAlgorithm(): string
+    public function algorithm(): string
     {
         return 'sha512';
     }

--- a/src/Signer/Hmac/Sha512.php
+++ b/src/Signer/Hmac/Sha512.php
@@ -7,7 +7,7 @@ use Lcobucci\JWT\Signer\Hmac;
 
 final class Sha512 extends Hmac
 {
-    public function getAlgorithmId(): string
+    public function algorithmId(): string
     {
         return 'HS512';
     }

--- a/src/Signer/None.php
+++ b/src/Signer/None.php
@@ -7,7 +7,7 @@ use Lcobucci\JWT\Signer;
 
 final class None implements Signer
 {
-    public function getAlgorithmId(): string
+    public function algorithmId(): string
     {
         return 'none';
     }

--- a/src/Signer/OpenSSL.php
+++ b/src/Signer/OpenSSL.php
@@ -35,7 +35,7 @@ abstract class OpenSSL implements Signer
         try {
             $signature = '';
 
-            if (! openssl_sign($payload, $signature, $key, $this->getAlgorithm())) {
+            if (! openssl_sign($payload, $signature, $key, $this->algorithm())) {
                 $error = openssl_error_string();
                 assert(is_string($error));
 
@@ -68,7 +68,7 @@ abstract class OpenSSL implements Signer
         string $pem
     ): bool {
         $key    = $this->getPublicKey($pem);
-        $result = openssl_verify($payload, $expected, $key, $this->getAlgorithm());
+        $result = openssl_verify($payload, $expected, $key, $this->algorithm());
         $this->freeKey($key);
 
         return $result === 1;
@@ -106,7 +106,7 @@ abstract class OpenSSL implements Signer
         $details = openssl_pkey_get_details($key);
         assert(is_array($details));
 
-        if (! array_key_exists('key', $details) || $details['type'] !== $this->getKeyType()) {
+        if (! array_key_exists('key', $details) || $details['type'] !== $this->keyType()) {
             throw InvalidKeyProvided::incompatibleKey();
         }
     }
@@ -126,12 +126,12 @@ abstract class OpenSSL implements Signer
      *
      * @internal
      */
-    abstract public function getKeyType(): int;
+    abstract public function keyType(): int;
 
     /**
      * Returns which algorithm to be used to create/verify the signature (using OpenSSL constants)
      *
      * @internal
      */
-    abstract public function getAlgorithm(): int;
+    abstract public function algorithm(): int;
 }

--- a/src/Signer/Rsa.php
+++ b/src/Signer/Rsa.php
@@ -17,7 +17,7 @@ abstract class Rsa extends OpenSSL
         return $this->verifySignature($expected, $payload, $key->contents());
     }
 
-    final public function getKeyType(): int
+    final public function keyType(): int
     {
         return OPENSSL_KEYTYPE_RSA;
     }

--- a/src/Signer/Rsa/Sha256.php
+++ b/src/Signer/Rsa/Sha256.php
@@ -9,7 +9,7 @@ use const OPENSSL_ALGO_SHA256;
 
 final class Sha256 extends Rsa
 {
-    public function getAlgorithmId(): string
+    public function algorithmId(): string
     {
         return 'RS256';
     }

--- a/src/Signer/Rsa/Sha256.php
+++ b/src/Signer/Rsa/Sha256.php
@@ -14,7 +14,7 @@ final class Sha256 extends Rsa
         return 'RS256';
     }
 
-    public function getAlgorithm(): int
+    public function algorithm(): int
     {
         return OPENSSL_ALGO_SHA256;
     }

--- a/src/Signer/Rsa/Sha384.php
+++ b/src/Signer/Rsa/Sha384.php
@@ -9,7 +9,7 @@ use const OPENSSL_ALGO_SHA384;
 
 final class Sha384 extends Rsa
 {
-    public function getAlgorithmId(): string
+    public function algorithmId(): string
     {
         return 'RS384';
     }

--- a/src/Signer/Rsa/Sha384.php
+++ b/src/Signer/Rsa/Sha384.php
@@ -14,7 +14,7 @@ final class Sha384 extends Rsa
         return 'RS384';
     }
 
-    public function getAlgorithm(): int
+    public function algorithm(): int
     {
         return OPENSSL_ALGO_SHA384;
     }

--- a/src/Signer/Rsa/Sha512.php
+++ b/src/Signer/Rsa/Sha512.php
@@ -14,7 +14,7 @@ final class Sha512 extends Rsa
         return 'RS512';
     }
 
-    public function getAlgorithm(): int
+    public function algorithm(): int
     {
         return OPENSSL_ALGO_SHA512;
     }

--- a/src/Signer/Rsa/Sha512.php
+++ b/src/Signer/Rsa/Sha512.php
@@ -9,7 +9,7 @@ use const OPENSSL_ALGO_SHA512;
 
 final class Sha512 extends Rsa
 {
-    public function getAlgorithmId(): string
+    public function algorithmId(): string
     {
         return 'RS512';
     }

--- a/src/Token/Builder.php
+++ b/src/Token/Builder.php
@@ -111,7 +111,7 @@ final class Builder implements BuilderInterface
     public function getToken(Signer $signer, Key $key): Plain
     {
         $headers        = $this->headers;
-        $headers['alg'] = $signer->getAlgorithmId();
+        $headers['alg'] = $signer->algorithmId();
 
         $encodedHeaders = $this->encode($headers);
         $encodedClaims  = $this->encode($this->claimFormatter->formatClaims($this->claims));

--- a/src/Validation/Constraint/SignedWith.php
+++ b/src/Validation/Constraint/SignedWith.php
@@ -25,7 +25,7 @@ final class SignedWith implements Constraint
             throw new ConstraintViolation('You should pass a plain token');
         }
 
-        if ($token->headers()->get('alg') !== $this->signer->getAlgorithmId()) {
+        if ($token->headers()->get('alg') !== $this->signer->algorithmId()) {
             throw new ConstraintViolation('Token signer mismatch');
         }
 

--- a/test/functional/HmacTokenTest.php
+++ b/test/functional/HmacTokenTest.php
@@ -47,14 +47,14 @@ class HmacTokenTest extends TestCase
     public function builderCanGenerateAToken(): Token
     {
         $user    = ['name' => 'testing', 'email' => 'testing@abc.com'];
-        $builder = $this->config->createBuilder();
+        $builder = $this->config->builder();
 
         $token = $builder->identifiedBy('1')
                          ->permittedFor('http://client.abc.com')
                          ->issuedBy('http://api.abc.com')
                          ->withClaim('user', $user)
                          ->withHeader('jki', '1234')
-                         ->getToken($this->config->getSigner(), $this->config->getSigningKey());
+                         ->getToken($this->config->signer(), $this->config->signingKey());
 
         self::assertEquals('1234', $token->headers()->get('jki'));
         self::assertEquals(['http://client.abc.com'], $token->claims()->get(Token\RegisteredClaims::AUDIENCE));
@@ -70,7 +70,7 @@ class HmacTokenTest extends TestCase
      */
     public function parserCanReadAToken(Token $generated): void
     {
-        $read = $this->config->getParser()->parse($generated->toString());
+        $read = $this->config->parser()->parse($generated->toString());
         assert($read instanceof Token\Plain);
 
         self::assertEquals($generated, $read);
@@ -86,9 +86,9 @@ class HmacTokenTest extends TestCase
         $this->expectException(RequiredConstraintsViolated::class);
         $this->expectExceptionMessage('The token violates some mandatory constraints');
 
-        $this->config->getValidator()->assert(
+        $this->config->validator()->assert(
             $token,
-            new SignedWith($this->config->getSigner(), InMemory::plainText('testing1'))
+            new SignedWith($this->config->signer(), InMemory::plainText('testing1'))
         );
     }
 
@@ -101,9 +101,9 @@ class HmacTokenTest extends TestCase
         $this->expectException(RequiredConstraintsViolated::class);
         $this->expectExceptionMessage('The token violates some mandatory constraints');
 
-        $this->config->getValidator()->assert(
+        $this->config->validator()->assert(
             $token,
-            new SignedWith(new Sha512(), $this->config->getVerificationKey())
+            new SignedWith(new Sha512(), $this->config->verificationKey())
         );
     }
 
@@ -113,9 +113,9 @@ class HmacTokenTest extends TestCase
      */
     public function signatureValidationShouldSucceedWhenKeyIsRight(Token $token): void
     {
-        $constraint = new SignedWith($this->config->getSigner(), $this->config->getVerificationKey());
+        $constraint = new SignedWith($this->config->signer(), $this->config->verificationKey());
 
-        self::assertTrue($this->config->getValidator()->validate($token, $constraint));
+        self::assertTrue($this->config->validator()->validate($token, $constraint));
     }
 
     /** @test */
@@ -124,11 +124,11 @@ class HmacTokenTest extends TestCase
         $data = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXUyJ9.eyJoZWxsbyI6IndvcmxkIn0.Rh'
                 . '7AEgqCB7zae1PkgIlvOpeyw9Ab8NGTbeOH7heHO0o';
 
-        $token = $this->config->getParser()->parse($data);
+        $token = $this->config->parser()->parse($data);
         assert($token instanceof Token\Plain);
-        $constraint = new SignedWith($this->config->getSigner(), $this->config->getVerificationKey());
+        $constraint = new SignedWith($this->config->signer(), $this->config->verificationKey());
 
-        self::assertTrue($this->config->getValidator()->validate($token, $constraint));
+        self::assertTrue($this->config->validator()->validate($token, $constraint));
         self::assertEquals('world', $token->claims()->get('hello'));
     }
 }

--- a/test/functional/MaliciousTamperingPreventionTest.php
+++ b/test/functional/MaliciousTamperingPreventionTest.php
@@ -80,15 +80,15 @@ final class MaliciousTamperingPreventionTest extends TestCase
          * (e.g. HMAC-SHA512 instead of ECDSA), they can forge messages!
          */
 
-        $token = $this->config->getParser()->parse($bad);
+        $token = $this->config->parser()->parse($bad);
         assert($token instanceof Plain);
 
         self::assertEquals('world', $token->claims()->get('hello'), 'The claim content should not be modified');
 
-        $validator = $this->config->getValidator();
+        $validator = $this->config->validator();
 
         self::assertFalse(
-            $validator->validate($token, new SignedWith(new HS512(), $this->config->getVerificationKey())),
+            $validator->validate($token, new SignedWith(new HS512(), $this->config->verificationKey())),
             'Using the attackers signer should make things unsafe'
         );
 
@@ -96,8 +96,8 @@ final class MaliciousTamperingPreventionTest extends TestCase
             $validator->validate(
                 $token,
                 new SignedWith(
-                    $this->config->getSigner(),
-                    $this->config->getVerificationKey()
+                    $this->config->signer(),
+                    $this->config->verificationKey()
                 )
             ),
             'But we know which Signer should be used so the attack fails'
@@ -116,7 +116,7 @@ final class MaliciousTamperingPreventionTest extends TestCase
         $hmac = hash_hmac(
             'sha512',
             $asplode[0] . '.' . $asplode[1],
-            $this->config->getVerificationKey()->contents(),
+            $this->config->verificationKey()->contents(),
             true
         );
 

--- a/test/functional/UnsignedTokenTest.php
+++ b/test/functional/UnsignedTokenTest.php
@@ -54,7 +54,7 @@ class UnsignedTokenTest extends TestCase
     public function builderCanGenerateAToken(): Token
     {
         $user    = ['name' => 'testing', 'email' => 'testing@abc.com'];
-        $builder = $this->config->createBuilder();
+        $builder = $this->config->builder();
 
         $expiration = new DateTimeImmutable('@' . (self::CURRENT_TIME + 3000));
 
@@ -63,7 +63,7 @@ class UnsignedTokenTest extends TestCase
                          ->issuedBy('http://api.abc.com')
                          ->expiresAt($expiration)
                          ->withClaim('user', $user)
-                         ->getToken($this->config->getSigner(), $this->config->getSigningKey());
+                         ->getToken($this->config->signer(), $this->config->signingKey());
 
         self::assertEquals(new Token\Signature('', ''), $token->signature());
         self::assertEquals(['http://client.abc.com'], $token->claims()->get(Token\RegisteredClaims::AUDIENCE));
@@ -80,7 +80,7 @@ class UnsignedTokenTest extends TestCase
      */
     public function parserCanReadAToken(Token $generated): void
     {
-        $read = $this->config->getParser()->parse($generated->toString());
+        $read = $this->config->parser()->parse($generated->toString());
         assert($read instanceof Token\Plain);
 
         self::assertEquals($generated, $read);
@@ -102,7 +102,7 @@ class UnsignedTokenTest extends TestCase
             new ValidAt($clock),
         ];
 
-        self::assertTrue($this->config->getValidator()->validate($generated, ...$constraints));
+        self::assertTrue($this->config->validator()->validate($generated, ...$constraints));
     }
 
     /**
@@ -111,7 +111,7 @@ class UnsignedTokenTest extends TestCase
      */
     public function tokenValidationShouldAllowCustomConstraint(Token $generated): void
     {
-        self::assertTrue($this->config->getValidator()->validate($generated, $this->validUserConstraint()));
+        self::assertTrue($this->config->validator()->validate($generated, $this->validUserConstraint()));
     }
 
     /**
@@ -128,7 +128,7 @@ class UnsignedTokenTest extends TestCase
         $this->expectException(RequiredConstraintsViolated::class);
         $this->expectExceptionMessage('The token violates some mandatory constraints');
 
-        $this->config->getValidator()->assert($generated, ...$constraints);
+        $this->config->validator()->assert($generated, ...$constraints);
     }
 
     private function validUserConstraint(): Constraint

--- a/test/unit/ConfigurationTest.php
+++ b/test/unit/ConfigurationTest.php
@@ -58,9 +58,9 @@ final class ConfigurationTest extends TestCase
      *
      * @covers ::forAsymmetricSigner
      * @covers ::__construct
-     * @covers ::getSigner
-     * @covers ::getSigningKey
-     * @covers ::getVerificationKey
+     * @covers ::signer
+     * @covers ::signingKey
+     * @covers ::verificationKey
      *
      * @uses \Lcobucci\JWT\Signer\Key\InMemory
      */
@@ -71,9 +71,9 @@ final class ConfigurationTest extends TestCase
 
         $config = Configuration::forAsymmetricSigner($this->signer, $signingKey, $verificationKey);
 
-        self::assertSame($this->signer, $config->getSigner());
-        self::assertSame($signingKey, $config->getSigningKey());
-        self::assertSame($verificationKey, $config->getVerificationKey());
+        self::assertSame($this->signer, $config->signer());
+        self::assertSame($signingKey, $config->signingKey());
+        self::assertSame($verificationKey, $config->verificationKey());
     }
 
     /**
@@ -81,9 +81,9 @@ final class ConfigurationTest extends TestCase
      *
      * @covers ::forSymmetricSigner
      * @covers ::__construct
-     * @covers ::getSigner
-     * @covers ::getSigningKey
-     * @covers ::getVerificationKey
+     * @covers ::signer
+     * @covers ::signingKey
+     * @covers ::verificationKey
      *
      * @uses \Lcobucci\JWT\Signer\Key\InMemory
      */
@@ -92,9 +92,9 @@ final class ConfigurationTest extends TestCase
         $key    = InMemory::plainText('private');
         $config = Configuration::forSymmetricSigner($this->signer, $key);
 
-        self::assertSame($this->signer, $config->getSigner());
-        self::assertSame($key, $config->getSigningKey());
-        self::assertSame($key, $config->getVerificationKey());
+        self::assertSame($this->signer, $config->signer());
+        self::assertSame($key, $config->signingKey());
+        self::assertSame($key, $config->verificationKey());
     }
 
     /**
@@ -102,9 +102,9 @@ final class ConfigurationTest extends TestCase
      *
      * @covers ::forUnsecuredSigner
      * @covers ::__construct
-     * @covers ::getSigner
-     * @covers ::getSigningKey
-     * @covers ::getVerificationKey
+     * @covers ::signer
+     * @covers ::signingKey
+     * @covers ::verificationKey
      *
      * @uses \Lcobucci\JWT\Signer\Key\InMemory
      */
@@ -113,15 +113,15 @@ final class ConfigurationTest extends TestCase
         $key    = InMemory::plainText('');
         $config = Configuration::forUnsecuredSigner();
 
-        self::assertInstanceOf(None::class, $config->getSigner());
-        self::assertEquals($key, $config->getSigningKey());
-        self::assertEquals($key, $config->getVerificationKey());
+        self::assertInstanceOf(None::class, $config->signer());
+        self::assertEquals($key, $config->signingKey());
+        self::assertEquals($key, $config->verificationKey());
     }
 
     /**
      * @test
      *
-     * @covers ::createBuilder
+     * @covers ::builder
      *
      * @uses \Lcobucci\JWT\Configuration::forUnsecuredSigner
      * @uses \Lcobucci\JWT\Configuration::__construct
@@ -129,10 +129,10 @@ final class ConfigurationTest extends TestCase
      * @uses \Lcobucci\JWT\Signer\None
      * @uses \Lcobucci\JWT\Signer\Key\InMemory
      */
-    public function createBuilderShouldCreateABuilderWithDefaultEncoderAndClaimFactory(): void
+    public function builderShouldCreateABuilderWithDefaultEncoderAndClaimFactory(): void
     {
         $config  = Configuration::forUnsecuredSigner();
-        $builder = $config->createBuilder();
+        $builder = $config->builder();
 
         self::assertInstanceOf(BuilderImpl::class, $builder);
         self::assertNotEquals(new BuilderImpl($this->encoder, ChainedFormatter::default()), $builder);
@@ -142,7 +142,7 @@ final class ConfigurationTest extends TestCase
     /**
      * @test
      *
-     * @covers ::createBuilder
+     * @covers ::builder
      * @covers ::__construct
      *
      * @uses \Lcobucci\JWT\Configuration::forUnsecuredSigner
@@ -150,10 +150,10 @@ final class ConfigurationTest extends TestCase
      * @uses \Lcobucci\JWT\Signer\None
      * @uses \Lcobucci\JWT\Signer\Key\InMemory
      */
-    public function createBuilderShouldCreateABuilderWithCustomizedEncoderAndClaimFactory(): void
+    public function builderShouldCreateABuilderWithCustomizedEncoderAndClaimFactory(): void
     {
         $config  = Configuration::forUnsecuredSigner($this->encoder);
-        $builder = $config->createBuilder();
+        $builder = $config->builder();
 
         self::assertInstanceOf(BuilderImpl::class, $builder);
         self::assertEquals(new BuilderImpl($this->encoder, ChainedFormatter::default()), $builder);
@@ -162,7 +162,7 @@ final class ConfigurationTest extends TestCase
     /**
      * @test
      *
-     * @covers ::createBuilder
+     * @covers ::builder
      * @covers ::setBuilderFactory
      *
      * @uses \Lcobucci\JWT\Configuration::forUnsecuredSigner
@@ -171,7 +171,7 @@ final class ConfigurationTest extends TestCase
      * @uses \Lcobucci\JWT\Signer\None
      * @uses \Lcobucci\JWT\Signer\Key\InMemory
      */
-    public function createBuilderShouldUseBuilderFactoryWhenThatIsConfigured(): void
+    public function builderShouldUseBuilderFactoryWhenThatIsConfigured(): void
     {
         $builder = $this->createMock(Builder::class);
 
@@ -181,23 +181,23 @@ final class ConfigurationTest extends TestCase
                 return $builder;
             }
         );
-        self::assertSame($builder, $config->createBuilder());
+        self::assertSame($builder, $config->builder());
     }
 
     /**
      * @test
      *
-     * @covers ::getParser
+     * @covers ::parser
      *
      * @uses \Lcobucci\JWT\Configuration::forUnsecuredSigner
      * @uses \Lcobucci\JWT\Configuration::__construct
      * @uses \Lcobucci\JWT\Signer\None
      * @uses \Lcobucci\JWT\Signer\Key\InMemory
      */
-    public function getParserShouldReturnAParserWithDefaultDecoder(): void
+    public function parserShouldReturnAParserWithDefaultDecoder(): void
     {
         $config = Configuration::forUnsecuredSigner();
-        $parser = $config->getParser();
+        $parser = $config->parser();
 
         self::assertNotEquals(new ParserImpl($this->decoder), $parser);
     }
@@ -205,17 +205,17 @@ final class ConfigurationTest extends TestCase
     /**
      * @test
      *
-     * @covers ::getParser
+     * @covers ::parser
      * @covers ::__construct
      *
      * @uses \Lcobucci\JWT\Configuration::forUnsecuredSigner
      * @uses \Lcobucci\JWT\Signer\None
      * @uses \Lcobucci\JWT\Signer\Key\InMemory
      */
-    public function getParserShouldReturnAParserWithCustomizedDecoder(): void
+    public function parserShouldReturnAParserWithCustomizedDecoder(): void
     {
         $config = Configuration::forUnsecuredSigner(null, $this->decoder);
-        $parser = $config->getParser();
+        $parser = $config->parser();
 
         self::assertEquals(new ParserImpl($this->decoder), $parser);
     }
@@ -223,7 +223,7 @@ final class ConfigurationTest extends TestCase
     /**
      * @test
      *
-     * @covers ::getParser
+     * @covers ::parser
      * @covers ::setParser
      *
      * @uses \Lcobucci\JWT\Configuration::forUnsecuredSigner
@@ -231,28 +231,28 @@ final class ConfigurationTest extends TestCase
      * @uses \Lcobucci\JWT\Signer\None
      * @uses \Lcobucci\JWT\Signer\Key\InMemory
      */
-    public function getParserShouldNotCreateAnInstanceIfItWasConfigured(): void
+    public function parserShouldNotCreateAnInstanceIfItWasConfigured(): void
     {
         $config = Configuration::forUnsecuredSigner();
         $config->setParser($this->parser);
 
-        self::assertSame($this->parser, $config->getParser());
+        self::assertSame($this->parser, $config->parser());
     }
 
     /**
      * @test
      *
-     * @covers ::getValidator
+     * @covers ::validator
      *
      * @uses \Lcobucci\JWT\Configuration::forUnsecuredSigner
      * @uses \Lcobucci\JWT\Configuration::__construct
      * @uses \Lcobucci\JWT\Signer\None
      * @uses \Lcobucci\JWT\Signer\Key\InMemory
      */
-    public function getValidatorShouldReturnTheDefaultWhenItWasNotConfigured(): void
+    public function validatorShouldReturnTheDefaultWhenItWasNotConfigured(): void
     {
         $config    = Configuration::forUnsecuredSigner();
-        $validator = $config->getValidator();
+        $validator = $config->validator();
 
         self::assertNotSame($this->validator, $validator);
     }
@@ -260,7 +260,7 @@ final class ConfigurationTest extends TestCase
     /**
      * @test
      *
-     * @covers ::getValidator
+     * @covers ::validator
      * @covers ::setValidator
      *
      * @uses \Lcobucci\JWT\Configuration::forUnsecuredSigner
@@ -268,35 +268,35 @@ final class ConfigurationTest extends TestCase
      * @uses \Lcobucci\JWT\Signer\None
      * @uses \Lcobucci\JWT\Signer\Key\InMemory
      */
-    public function getValidatorShouldReturnTheConfiguredValidator(): void
+    public function validatorShouldReturnTheConfiguredValidator(): void
     {
         $config = Configuration::forUnsecuredSigner();
         $config->setValidator($this->validator);
 
-        self::assertSame($this->validator, $config->getValidator());
+        self::assertSame($this->validator, $config->validator());
     }
 
     /**
      * @test
      *
-     * @covers ::getValidationConstraints
+     * @covers ::validationConstraints
      *
      * @uses \Lcobucci\JWT\Configuration::forUnsecuredSigner
      * @uses \Lcobucci\JWT\Configuration::__construct
      * @uses \Lcobucci\JWT\Signer\None
      * @uses \Lcobucci\JWT\Signer\Key\InMemory
      */
-    public function getValidationConstraintsShouldReturnAnEmptyArrayWhenItWasNotConfigured(): void
+    public function validationConstraintsShouldReturnAnEmptyArrayWhenItWasNotConfigured(): void
     {
         $config = Configuration::forUnsecuredSigner();
 
-        self::assertSame([], $config->getValidationConstraints());
+        self::assertSame([], $config->validationConstraints());
     }
 
     /**
      * @test
      *
-     * @covers ::getValidationConstraints
+     * @covers ::validationConstraints
      * @covers ::setValidationConstraints
      *
      * @uses \Lcobucci\JWT\Configuration::forUnsecuredSigner
@@ -304,18 +304,18 @@ final class ConfigurationTest extends TestCase
      * @uses \Lcobucci\JWT\Signer\None
      * @uses \Lcobucci\JWT\Signer\Key\InMemory
      */
-    public function getValidationConstraintsShouldReturnTheConfiguredValidator(): void
+    public function validationConstraintsShouldReturnTheConfiguredValidator(): void
     {
         $config = Configuration::forUnsecuredSigner();
         $config->setValidationConstraints($this->validationConstraints);
 
-        self::assertSame([$this->validationConstraints], $config->getValidationConstraints());
+        self::assertSame([$this->validationConstraints], $config->validationConstraints());
     }
 
     /**
      * @test
      *
-     * @covers ::createBuilder
+     * @covers ::builder
      *
      * @uses \Lcobucci\JWT\Configuration::forUnsecuredSigner
      * @uses \Lcobucci\JWT\Configuration::__construct
@@ -327,6 +327,6 @@ final class ConfigurationTest extends TestCase
         $formatter = $this->createMock(ClaimsFormatter::class);
         $config    = Configuration::forUnsecuredSigner();
 
-        self::assertEquals(new BuilderImpl(new JoseEncoder(), $formatter), $config->createBuilder($formatter));
+        self::assertEquals(new BuilderImpl(new JoseEncoder(), $formatter), $config->builder($formatter));
     }
 }

--- a/test/unit/Signer/Ecdsa/Sha256Test.php
+++ b/test/unit/Signer/Ecdsa/Sha256Test.php
@@ -40,25 +40,25 @@ final class Sha256Test extends TestCase
     /**
      * @test
      *
-     * @covers ::getAlgorithm
+     * @covers ::algorithm
      *
      * @uses \Lcobucci\JWT\Signer\Ecdsa
      */
-    public function getAlgorithmMustBeCorrect(): void
+    public function algorithmMustBeCorrect(): void
     {
-        self::assertSame(OPENSSL_ALGO_SHA256, $this->getSigner()->getAlgorithm());
+        self::assertSame(OPENSSL_ALGO_SHA256, $this->getSigner()->algorithm());
     }
 
     /**
      * @test
      *
-     * @covers ::getKeyLength
+     * @covers ::keyLength
      *
      * @uses \Lcobucci\JWT\Signer\Ecdsa
      */
-    public function getKeyLengthMustBeCorrect(): void
+    public function keyLengthMustBeCorrect(): void
     {
-        self::assertSame(64, $this->getSigner()->getKeyLength());
+        self::assertSame(64, $this->getSigner()->keyLength());
     }
 
     private function getSigner(): Sha256

--- a/test/unit/Signer/Ecdsa/Sha256Test.php
+++ b/test/unit/Signer/Ecdsa/Sha256Test.php
@@ -28,13 +28,13 @@ final class Sha256Test extends TestCase
     /**
      * @test
      *
-     * @covers ::getAlgorithmId
+     * @covers ::algorithmId
      *
      * @uses \Lcobucci\JWT\Signer\Ecdsa
      */
-    public function getAlgorithmIdMustBeCorrect(): void
+    public function algorithmIdMustBeCorrect(): void
     {
-        self::assertSame('ES256', $this->getSigner()->getAlgorithmId());
+        self::assertSame('ES256', $this->getSigner()->algorithmId());
     }
 
     /**

--- a/test/unit/Signer/Ecdsa/Sha384Test.php
+++ b/test/unit/Signer/Ecdsa/Sha384Test.php
@@ -28,13 +28,13 @@ final class Sha384Test extends TestCase
     /**
      * @test
      *
-     * @covers ::getAlgorithmId
+     * @covers ::algorithmId
      *
      * @uses \Lcobucci\JWT\Signer\Ecdsa
      */
-    public function getAlgorithmIdMustBeCorrect(): void
+    public function algorithmIdMustBeCorrect(): void
     {
-        self::assertSame('ES384', $this->getSigner()->getAlgorithmId());
+        self::assertSame('ES384', $this->getSigner()->algorithmId());
     }
 
     /**

--- a/test/unit/Signer/Ecdsa/Sha384Test.php
+++ b/test/unit/Signer/Ecdsa/Sha384Test.php
@@ -40,25 +40,25 @@ final class Sha384Test extends TestCase
     /**
      * @test
      *
-     * @covers ::getAlgorithm
+     * @covers ::algorithm
      *
      * @uses \Lcobucci\JWT\Signer\Ecdsa
      */
-    public function getAlgorithmMustBeCorrect(): void
+    public function algorithmMustBeCorrect(): void
     {
-        self::assertSame(OPENSSL_ALGO_SHA384, $this->getSigner()->getAlgorithm());
+        self::assertSame(OPENSSL_ALGO_SHA384, $this->getSigner()->algorithm());
     }
 
     /**
      * @test
      *
-     * @covers ::getKeyLength
+     * @covers ::keyLength
      *
      * @uses \Lcobucci\JWT\Signer\Ecdsa
      */
-    public function getKeyLengthMustBeCorrect(): void
+    public function keyLengthMustBeCorrect(): void
     {
-        self::assertSame(96, $this->getSigner()->getKeyLength());
+        self::assertSame(96, $this->getSigner()->keyLength());
     }
 
     private function getSigner(): Sha384

--- a/test/unit/Signer/Ecdsa/Sha512Test.php
+++ b/test/unit/Signer/Ecdsa/Sha512Test.php
@@ -40,25 +40,25 @@ final class Sha512Test extends TestCase
     /**
      * @test
      *
-     * @covers ::getAlgorithm
+     * @covers ::algorithm
      *
      * @uses \Lcobucci\JWT\Signer\Ecdsa
      */
-    public function getAlgorithmMustBeCorrect(): void
+    public function algorithmMustBeCorrect(): void
     {
-        self::assertSame(OPENSSL_ALGO_SHA512, $this->getSigner()->getAlgorithm());
+        self::assertSame(OPENSSL_ALGO_SHA512, $this->getSigner()->algorithm());
     }
 
     /**
      * @test
      *
-     * @covers ::getKeyLength
+     * @covers ::keyLength
      *
      * @uses \Lcobucci\JWT\Signer\Ecdsa
      */
-    public function getKeyLengthMustBeCorrect(): void
+    public function keyLengthMustBeCorrect(): void
     {
-        self::assertSame(132, $this->getSigner()->getKeyLength());
+        self::assertSame(132, $this->getSigner()->keyLength());
     }
 
     private function getSigner(): Sha512

--- a/test/unit/Signer/Ecdsa/Sha512Test.php
+++ b/test/unit/Signer/Ecdsa/Sha512Test.php
@@ -28,13 +28,13 @@ final class Sha512Test extends TestCase
     /**
      * @test
      *
-     * @covers ::getAlgorithmId
+     * @covers ::algorithmId
      *
      * @uses \Lcobucci\JWT\Signer\Ecdsa
      */
-    public function getAlgorithmIdMustBeCorrect(): void
+    public function algorithmIdMustBeCorrect(): void
     {
-        self::assertSame('ES512', $this->getSigner()->getAlgorithmId());
+        self::assertSame('ES512', $this->getSigner()->algorithmId());
     }
 
     /**

--- a/test/unit/Signer/EcdsaTest.php
+++ b/test/unit/Signer/EcdsaTest.php
@@ -34,13 +34,13 @@ final class EcdsaTest extends TestCase
     {
         $signer = $this->getMockForAbstractClass(Ecdsa::class, [$this->pointsManipulator]);
 
-        $signer->method('getAlgorithm')
+        $signer->method('algorithm')
                ->willReturn(OPENSSL_ALGO_SHA256);
 
         $signer->method('algorithmId')
                ->willReturn('ES256');
 
-        $signer->method('getKeyLength')
+        $signer->method('keyLength')
                ->willReturn(64);
 
         return $signer;
@@ -50,7 +50,7 @@ final class EcdsaTest extends TestCase
      * @test
      *
      * @covers ::sign
-     * @covers ::getKeyType
+     * @covers ::keyType
      * @covers \Lcobucci\JWT\Signer\Ecdsa\MultibyteStringConverter
      * @covers \Lcobucci\JWT\Signer\OpenSSL
      *
@@ -71,7 +71,7 @@ final class EcdsaTest extends TestCase
             1,
             openssl_verify(
                 $payload,
-                $this->pointsManipulator->toAsn1($signature, $signer->getKeyLength()),
+                $this->pointsManipulator->toAsn1($signature, $signer->keyLength()),
                 $publicKey,
                 OPENSSL_ALGO_SHA256
             )
@@ -82,7 +82,7 @@ final class EcdsaTest extends TestCase
      * @test
      *
      * @covers ::verify
-     * @covers ::getKeyType
+     * @covers ::keyType
      * @covers \Lcobucci\JWT\Signer\Ecdsa\MultibyteStringConverter
      * @covers \Lcobucci\JWT\Signer\OpenSSL
      *
@@ -102,7 +102,7 @@ final class EcdsaTest extends TestCase
 
         self::assertTrue(
             $signer->verify(
-                $this->pointsManipulator->fromAsn1($signature, $signer->getKeyLength()),
+                $this->pointsManipulator->fromAsn1($signature, $signer->keyLength()),
                 $payload,
                 self::$ecdsaKeys['public1']
             )

--- a/test/unit/Signer/EcdsaTest.php
+++ b/test/unit/Signer/EcdsaTest.php
@@ -37,7 +37,7 @@ final class EcdsaTest extends TestCase
         $signer->method('getAlgorithm')
                ->willReturn(OPENSSL_ALGO_SHA256);
 
-        $signer->method('getAlgorithmId')
+        $signer->method('algorithmId')
                ->willReturn('ES256');
 
         $signer->method('getKeyLength')

--- a/test/unit/Signer/Hmac/Sha256Test.php
+++ b/test/unit/Signer/Hmac/Sha256Test.php
@@ -23,12 +23,12 @@ final class Sha256Test extends TestCase
     /**
      * @test
      *
-     * @covers ::getAlgorithm
+     * @covers ::algorithm
      */
-    public function getAlgorithmMustBeCorrect(): void
+    public function algorithmMustBeCorrect(): void
     {
         $signer = new Sha256();
 
-        self::assertEquals('sha256', $signer->getAlgorithm());
+        self::assertEquals('sha256', $signer->algorithm());
     }
 }

--- a/test/unit/Signer/Hmac/Sha256Test.php
+++ b/test/unit/Signer/Hmac/Sha256Test.php
@@ -11,13 +11,13 @@ final class Sha256Test extends TestCase
     /**
      * @test
      *
-     * @covers ::getAlgorithmId
+     * @covers ::algorithmId
      */
-    public function getAlgorithmIdMustBeCorrect(): void
+    public function algorithmIdMustBeCorrect(): void
     {
         $signer = new Sha256();
 
-        self::assertEquals('HS256', $signer->getAlgorithmId());
+        self::assertEquals('HS256', $signer->algorithmId());
     }
 
     /**

--- a/test/unit/Signer/Hmac/Sha384Test.php
+++ b/test/unit/Signer/Hmac/Sha384Test.php
@@ -23,12 +23,12 @@ final class Sha384Test extends TestCase
     /**
      * @test
      *
-     * @covers ::getAlgorithm
+     * @covers ::algorithm
      */
-    public function getAlgorithmMustBeCorrect(): void
+    public function algorithmMustBeCorrect(): void
     {
         $signer = new Sha384();
 
-        self::assertEquals('sha384', $signer->getAlgorithm());
+        self::assertEquals('sha384', $signer->algorithm());
     }
 }

--- a/test/unit/Signer/Hmac/Sha384Test.php
+++ b/test/unit/Signer/Hmac/Sha384Test.php
@@ -11,13 +11,13 @@ final class Sha384Test extends TestCase
     /**
      * @test
      *
-     * @covers ::getAlgorithmId
+     * @covers ::algorithmId
      */
-    public function getAlgorithmIdMustBeCorrect(): void
+    public function algorithmIdMustBeCorrect(): void
     {
         $signer = new Sha384();
 
-        self::assertEquals('HS384', $signer->getAlgorithmId());
+        self::assertEquals('HS384', $signer->algorithmId());
     }
 
     /**

--- a/test/unit/Signer/Hmac/Sha512Test.php
+++ b/test/unit/Signer/Hmac/Sha512Test.php
@@ -11,13 +11,13 @@ final class Sha512Test extends TestCase
     /**
      * @test
      *
-     * @covers ::getAlgorithmId
+     * @covers ::algorithmId
      */
-    public function getAlgorithmIdMustBeCorrect(): void
+    public function algorithmIdMustBeCorrect(): void
     {
         $signer = new Sha512();
 
-        self::assertEquals('HS512', $signer->getAlgorithmId());
+        self::assertEquals('HS512', $signer->algorithmId());
     }
 
     /**

--- a/test/unit/Signer/Hmac/Sha512Test.php
+++ b/test/unit/Signer/Hmac/Sha512Test.php
@@ -23,12 +23,12 @@ final class Sha512Test extends TestCase
     /**
      * @test
      *
-     * @covers ::getAlgorithm
+     * @covers ::algorithm
      */
-    public function getAlgorithmMustBeCorrect(): void
+    public function algorithmMustBeCorrect(): void
     {
         $signer = new Sha512();
 
-        self::assertEquals('sha512', $signer->getAlgorithm());
+        self::assertEquals('sha512', $signer->algorithm());
     }
 }

--- a/test/unit/Signer/HmacTest.php
+++ b/test/unit/Signer/HmacTest.php
@@ -25,7 +25,7 @@ final class HmacTest extends TestCase
                      ->willReturn('TEST123');
 
         $this->signer->expects(self::any())
-                     ->method('getAlgorithm')
+                     ->method('algorithm')
                      ->willReturn('sha256');
     }
 

--- a/test/unit/Signer/HmacTest.php
+++ b/test/unit/Signer/HmacTest.php
@@ -21,7 +21,7 @@ final class HmacTest extends TestCase
         $this->signer = $this->getMockForAbstractClass(Hmac::class);
 
         $this->signer->expects(self::any())
-                     ->method('getAlgorithmId')
+                     ->method('algorithmId')
                      ->willReturn('TEST123');
 
         $this->signer->expects(self::any())

--- a/test/unit/Signer/NoneTest.php
+++ b/test/unit/Signer/NoneTest.php
@@ -12,13 +12,13 @@ final class NoneTest extends TestCase
     /**
      * @test
      *
-     * @covers ::getAlgorithmId
+     * @covers ::algorithmId
      */
-    public function getAlgorithmIdMustBeCorrect(): void
+    public function algorithmIdMustBeCorrect(): void
     {
         $signer = new None();
 
-        self::assertEquals('none', $signer->getAlgorithmId());
+        self::assertEquals('none', $signer->algorithmId());
     }
 
     /**

--- a/test/unit/Signer/Rsa/Sha256Test.php
+++ b/test/unit/Signer/Rsa/Sha256Test.php
@@ -25,12 +25,12 @@ final class Sha256Test extends TestCase
     /**
      * @test
      *
-     * @covers ::getAlgorithm
+     * @covers ::algorithm
      */
-    public function getAlgorithmMustBeCorrect(): void
+    public function algorithmMustBeCorrect(): void
     {
         $signer = new Sha256();
 
-        self::assertEquals(OPENSSL_ALGO_SHA256, $signer->getAlgorithm());
+        self::assertEquals(OPENSSL_ALGO_SHA256, $signer->algorithm());
     }
 }

--- a/test/unit/Signer/Rsa/Sha256Test.php
+++ b/test/unit/Signer/Rsa/Sha256Test.php
@@ -13,13 +13,13 @@ final class Sha256Test extends TestCase
     /**
      * @test
      *
-     * @covers ::getAlgorithmId
+     * @covers ::algorithmId
      */
-    public function getAlgorithmIdMustBeCorrect(): void
+    public function algorithmIdMustBeCorrect(): void
     {
         $signer = new Sha256();
 
-        self::assertEquals('RS256', $signer->getAlgorithmId());
+        self::assertEquals('RS256', $signer->algorithmId());
     }
 
     /**

--- a/test/unit/Signer/Rsa/Sha384Test.php
+++ b/test/unit/Signer/Rsa/Sha384Test.php
@@ -13,13 +13,13 @@ final class Sha384Test extends TestCase
     /**
      * @test
      *
-     * @covers ::getAlgorithmId
+     * @covers ::algorithmId
      */
-    public function getAlgorithmIdMustBeCorrect(): void
+    public function algorithmIdMustBeCorrect(): void
     {
         $signer = new Sha384();
 
-        self::assertEquals('RS384', $signer->getAlgorithmId());
+        self::assertEquals('RS384', $signer->algorithmId());
     }
 
     /**

--- a/test/unit/Signer/Rsa/Sha384Test.php
+++ b/test/unit/Signer/Rsa/Sha384Test.php
@@ -25,12 +25,12 @@ final class Sha384Test extends TestCase
     /**
      * @test
      *
-     * @covers ::getAlgorithm
+     * @covers ::algorithm
      */
-    public function getAlgorithmMustBeCorrect(): void
+    public function algorithmMustBeCorrect(): void
     {
         $signer = new Sha384();
 
-        self::assertEquals(OPENSSL_ALGO_SHA384, $signer->getAlgorithm());
+        self::assertEquals(OPENSSL_ALGO_SHA384, $signer->algorithm());
     }
 }

--- a/test/unit/Signer/Rsa/Sha512Test.php
+++ b/test/unit/Signer/Rsa/Sha512Test.php
@@ -13,13 +13,13 @@ final class Sha512Test extends TestCase
     /**
      * @test
      *
-     * @covers ::getAlgorithmId
+     * @covers ::algorithmId
      */
-    public function getAlgorithmIdMustBeCorrect(): void
+    public function algorithmIdMustBeCorrect(): void
     {
         $signer = new Sha512();
 
-        self::assertEquals('RS512', $signer->getAlgorithmId());
+        self::assertEquals('RS512', $signer->algorithmId());
     }
 
     /**

--- a/test/unit/Signer/Rsa/Sha512Test.php
+++ b/test/unit/Signer/Rsa/Sha512Test.php
@@ -25,12 +25,12 @@ final class Sha512Test extends TestCase
     /**
      * @test
      *
-     * @covers ::getAlgorithm
+     * @covers ::algorithm
      */
-    public function getAlgorithmMustBeCorrect(): void
+    public function algorithmMustBeCorrect(): void
     {
         $signer = new Sha512();
 
-        self::assertEquals(OPENSSL_ALGO_SHA512, $signer->getAlgorithm());
+        self::assertEquals(OPENSSL_ALGO_SHA512, $signer->algorithm());
     }
 }

--- a/test/unit/Signer/RsaTest.php
+++ b/test/unit/Signer/RsaTest.php
@@ -179,7 +179,7 @@ KEY;
         $signer->method('getAlgorithm')
                ->willReturn(OPENSSL_ALGO_SHA256);
 
-        $signer->method('getAlgorithmId')
+        $signer->method('algorithmId')
                ->willReturn('RS256');
 
         return $signer;

--- a/test/unit/Signer/RsaTest.php
+++ b/test/unit/Signer/RsaTest.php
@@ -26,7 +26,7 @@ final class RsaTest extends TestCase
      * @test
      *
      * @covers ::sign
-     * @covers ::getKeyType
+     * @covers ::keyType
      * @covers \Lcobucci\JWT\Signer\OpenSSL
      *
      * @uses \Lcobucci\JWT\Signer\Key\LocalFileReference
@@ -48,7 +48,7 @@ final class RsaTest extends TestCase
      * @test
      *
      * @covers ::sign
-     * @covers ::getKeyType
+     * @covers ::keyType
      * @covers \Lcobucci\JWT\Signer\OpenSSL
      * @covers \Lcobucci\JWT\Signer\CannotSignPayload
      *
@@ -95,7 +95,7 @@ KEY;
      * @test
      *
      * @covers ::sign
-     * @covers ::getKeyType
+     * @covers ::keyType
      * @covers \Lcobucci\JWT\Signer\OpenSSL
      * @covers \Lcobucci\JWT\Signer\InvalidKeyProvided
      *
@@ -115,7 +115,7 @@ KEY;
      * @test
      *
      * @covers ::verify
-     * @covers ::getKeyType
+     * @covers ::keyType
      * @covers \Lcobucci\JWT\Signer\OpenSSL
      *
      * @uses \Lcobucci\JWT\Signer\Key\LocalFileReference
@@ -176,7 +176,7 @@ KEY;
     {
         $signer = $this->getMockForAbstractClass(Rsa::class);
 
-        $signer->method('getAlgorithm')
+        $signer->method('algorithm')
                ->willReturn(OPENSSL_ALGO_SHA256);
 
         $signer->method('algorithmId')

--- a/test/unit/Token/BuilderTest.php
+++ b/test/unit/Token/BuilderTest.php
@@ -29,7 +29,7 @@ final class BuilderTest extends TestCase
     {
         $this->encoder = $this->createMock(Encoder::class);
         $this->signer  = $this->createMock(Signer::class);
-        $this->signer->method('getAlgorithmId')->willReturn('RS256');
+        $this->signer->method('algorithmId')->willReturn('RS256');
     }
 
     /**

--- a/test/unit/Validation/Constraint/SignedWithTest.php
+++ b/test/unit/Validation/Constraint/SignedWithTest.php
@@ -21,7 +21,7 @@ final class SignedWithTest extends ConstraintTestCase
     public function createDependencies(): void
     {
         $this->signer = $this->createMock(Signer::class);
-        $this->signer->method('getAlgorithmId')->willReturn('RS256');
+        $this->signer->method('algorithmId')->willReturn('RS256');
 
         $this->key       = Signer\Key\InMemory::plainText('123');
         $this->signature = new Signature('1234', '5678');


### PR DESCRIPTION
This removes the `get` prefix from methods, making it easier to provide the migration path on v3.4. 