### PR TITLE
Only prefix file:// if doesn't exist already

### DIFF
--- a/src/Signer/Key/LocalFileReference.php
+++ b/src/Signer/Key/LocalFileReference.php
@@ -6,9 +6,13 @@ namespace Lcobucci\JWT\Signer\Key;
 use Lcobucci\JWT\Signer\Key;
 
 use function file_exists;
+use function strpos;
+use function substr;
 
 final class LocalFileReference implements Key
 {
+    private const PATH_PREFIX = 'file://';
+
     private string $path;
     private string $passphrase;
 
@@ -21,6 +25,10 @@ final class LocalFileReference implements Key
     /** @throws FileCouldNotBeRead */
     public static function file(string $path, string $passphrase = ''): self
     {
+        if (strpos($path, self::PATH_PREFIX) === 0) {
+            $path = substr($path, 7);
+        }
+
         if (! file_exists($path)) {
             throw FileCouldNotBeRead::onPath($path);
         }
@@ -30,7 +38,7 @@ final class LocalFileReference implements Key
 
     public function contents(): string
     {
-        return 'file://' . $this->path;
+        return self::PATH_PREFIX . $this->path;
     }
 
     public function passphrase(): string

--- a/test/unit/Signer/Key/LocalFileReferenceTest.php
+++ b/test/unit/Signer/Key/LocalFileReferenceTest.php
@@ -39,6 +39,20 @@ final class LocalFileReferenceTest extends TestCase
      * @covers ::file
      * @covers ::__construct
      * @covers ::contents
+     */
+    public function pathShouldBeNormalised(): void
+    {
+        $key = LocalFileReference::file('file://' . vfsStream::url('root/test.pem'));
+
+        self::assertSame('file://vfs://root/test.pem', $key->contents());
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::file
+     * @covers ::__construct
+     * @covers ::contents
      * @covers ::passphrase
      */
     public function contentsShouldReturnOnlyTheReferenceToTheFile(): void


### PR DESCRIPTION
This small change only prefixes key paths with _file://_ if the prefix doesn't exist already.

Apologies but I haven't added any tests for this. If you would like me to, please just shout and I will try to get to them tomorrow. Cheers Luis