### PR TITLE
Use magic method for toString

### DIFF
--- a/src/Token.php
+++ b/src/Token.php
@@ -51,5 +51,5 @@ interface Token
     /**
      * Returns an encoded representation of the token
      */
-    public function toString(): string;
+    public function __toString(): string;
 }

--- a/src/Token/DataSet.php
+++ b/src/Token/DataSet.php
@@ -39,7 +39,7 @@ final class DataSet
         return $this->data;
     }
 
-    public function toString(): string
+    public function __toString(): string
     {
         return $this->encoded;
     }

--- a/src/Token/Plain.php
+++ b/src/Token/Plain.php
@@ -41,7 +41,7 @@ final class Plain implements TokenInterface
 
     public function payload(): string
     {
-        return $this->headers->toString() . '.' . $this->claims->toString();
+        return $this->headers . '.' . $this->claims;
     }
 
     public function isPermittedFor(string $audience): bool
@@ -83,10 +83,10 @@ final class Plain implements TokenInterface
         return $now > $this->claims->get(RegisteredClaims::EXPIRATION_TIME);
     }
 
-    public function toString(): string
+    public function __toString(): string
     {
-        return $this->headers->toString() . '.'
-             . $this->claims->toString() . '.'
-             . $this->signature->toString();
+        return $this->headers . '.'
+             . $this->claims . '.'
+             . $this->signature;
     }
 }

--- a/src/Token/Signature.php
+++ b/src/Token/Signature.php
@@ -27,7 +27,7 @@ final class Signature
     /**
      * Returns the encoded version of the signature
      */
-    public function toString(): string
+    public function __toString(): string
     {
         return $this->encoded;
     }

--- a/test/functional/ES512TokenTest.php
+++ b/test/functional/ES512TokenTest.php
@@ -117,7 +117,7 @@ class ES512TokenTest extends TestCase
      */
     public function parserCanReadAToken(Token $generated): void
     {
-        $read = $this->config->parser()->parse($generated->toString());
+        $read = $this->config->parser()->parse($generated);
         assert($read instanceof Token\Plain);
 
         self::assertEquals($generated, $read);

--- a/test/functional/ES512TokenTest.php
+++ b/test/functional/ES512TokenTest.php
@@ -117,7 +117,7 @@ class ES512TokenTest extends TestCase
      */
     public function parserCanReadAToken(Token $generated): void
     {
-        $read = $this->config->parser()->parse($generated);
+        $read = $this->config->parser()->parse((string) $generated);
         assert($read instanceof Token\Plain);
 
         self::assertEquals($generated, $read);

--- a/test/functional/EcdsaTokenTest.php
+++ b/test/functional/EcdsaTokenTest.php
@@ -121,7 +121,7 @@ class EcdsaTokenTest extends TestCase
      */
     public function parserCanReadAToken(Token $generated): void
     {
-        $read = $this->config->parser()->parse($generated);
+        $read = $this->config->parser()->parse((string) $generated);
         assert($read instanceof Token\Plain);
 
         self::assertEquals($generated, $read);

--- a/test/functional/EcdsaTokenTest.php
+++ b/test/functional/EcdsaTokenTest.php
@@ -121,7 +121,7 @@ class EcdsaTokenTest extends TestCase
      */
     public function parserCanReadAToken(Token $generated): void
     {
-        $read = $this->config->parser()->parse($generated->toString());
+        $read = $this->config->parser()->parse($generated);
         assert($read instanceof Token\Plain);
 
         self::assertEquals($generated, $read);

--- a/test/functional/HmacTokenTest.php
+++ b/test/functional/HmacTokenTest.php
@@ -70,7 +70,7 @@ class HmacTokenTest extends TestCase
      */
     public function parserCanReadAToken(Token $generated): void
     {
-        $read = $this->config->parser()->parse($generated->toString());
+        $read = $this->config->parser()->parse($generated);
         assert($read instanceof Token\Plain);
 
         self::assertEquals($generated, $read);

--- a/test/functional/HmacTokenTest.php
+++ b/test/functional/HmacTokenTest.php
@@ -70,7 +70,7 @@ class HmacTokenTest extends TestCase
      */
     public function parserCanReadAToken(Token $generated): void
     {
-        $read = $this->config->parser()->parse($generated);
+        $read = $this->config->parser()->parse((string) $generated);
         assert($read instanceof Token\Plain);
 
         self::assertEquals($generated, $read);

--- a/test/functional/RsaTokenTest.php
+++ b/test/functional/RsaTokenTest.php
@@ -111,7 +111,7 @@ class RsaTokenTest extends TestCase
      */
     public function parserCanReadAToken(Token $generated): void
     {
-        $read = $this->config->parser()->parse($generated);
+        $read = $this->config->parser()->parse((string) $generated);
         assert($read instanceof Token\Plain);
 
         self::assertEquals($generated, $read);

--- a/test/functional/RsaTokenTest.php
+++ b/test/functional/RsaTokenTest.php
@@ -111,7 +111,7 @@ class RsaTokenTest extends TestCase
      */
     public function parserCanReadAToken(Token $generated): void
     {
-        $read = $this->config->parser()->parse($generated->toString());
+        $read = $this->config->parser()->parse($generated);
         assert($read instanceof Token\Plain);
 
         self::assertEquals($generated, $read);

--- a/test/functional/UnsignedTokenTest.php
+++ b/test/functional/UnsignedTokenTest.php
@@ -80,7 +80,7 @@ class UnsignedTokenTest extends TestCase
      */
     public function parserCanReadAToken(Token $generated): void
     {
-        $read = $this->config->parser()->parse($generated);
+        $read = $this->config->parser()->parse((string) $generated);
         assert($read instanceof Token\Plain);
 
         self::assertEquals($generated, $read);

--- a/test/functional/UnsignedTokenTest.php
+++ b/test/functional/UnsignedTokenTest.php
@@ -80,7 +80,7 @@ class UnsignedTokenTest extends TestCase
      */
     public function parserCanReadAToken(Token $generated): void
     {
-        $read = $this->config->parser()->parse($generated->toString());
+        $read = $this->config->parser()->parse($generated);
         assert($read instanceof Token\Plain);
 
         self::assertEquals($generated, $read);

--- a/test/unit/Token/BuilderTest.php
+++ b/test/unit/Token/BuilderTest.php
@@ -116,6 +116,6 @@ final class BuilderTest extends TestCase
         self::assertSame('https://issuer.com', $token->claims()->get(RegisteredClaims::ISSUER));
         self::assertSame('subject', $token->claims()->get(RegisteredClaims::SUBJECT));
         self::assertSame(['test1', 'test2'], $token->claims()->get(RegisteredClaims::AUDIENCE));
-        self::assertSame('3', $token->signature()->toString());
+        self::assertSame('3', (string) $token->signature());
     }
 }

--- a/test/unit/Token/DataSetTest.php
+++ b/test/unit/Token/DataSetTest.php
@@ -97,12 +97,12 @@ final class DataSetTest extends TestCase
      * @test
      *
      * @covers ::__construct
-     * @covers ::toString
+     * @covers ::__toString
      */
     public function toStringShouldReturnTheEncodedData(): void
     {
         $set = new DataSet(['one' => 1], 'one=1');
 
-        self::assertSame('one=1', $set->toString());
+        self::assertSame('one=1', (string) $set);
     }
 }

--- a/test/unit/Token/PlainTest.php
+++ b/test/unit/Token/PlainTest.php
@@ -557,7 +557,7 @@ final class PlainTest extends TestCase
     /**
      * @test
      *
-     * @covers ::toString
+     * @covers ::__toString
      *
      * @uses \Lcobucci\JWT\Token\Plain::__construct
      * @uses \Lcobucci\JWT\Token\Plain::payload
@@ -568,13 +568,13 @@ final class PlainTest extends TestCase
     {
         $token = $this->createToken(null, null, Signature::fromEmptyData());
 
-        self::assertSame('headers.claims.', $token->toString());
+        self::assertSame('headers.claims.', (string) $token);
     }
 
     /**
      * @test
      *
-     * @covers ::toString
+     * @covers ::__toString
      *
      * @uses \Lcobucci\JWT\Token\Plain::__construct
      * @uses \Lcobucci\JWT\Token\DataSet
@@ -584,6 +584,6 @@ final class PlainTest extends TestCase
     {
         $token = $this->createToken();
 
-        self::assertSame('headers.claims.signature', $token->toString());
+        self::assertSame('headers.claims.signature', (string) $token);
     }
 }

--- a/test/unit/Token/SignatureTest.php
+++ b/test/unit/Token/SignatureTest.php
@@ -13,7 +13,7 @@ final class SignatureTest extends TestCase
      *
      * @covers ::__construct
      * @covers ::fromEmptyData
-     * @covers ::toString
+     * @covers ::__toString
      * @covers ::hash
      */
     public function fromEmptyDataShouldReturnAnEmptySignature(): void
@@ -21,7 +21,7 @@ final class SignatureTest extends TestCase
         $signature = Signature::fromEmptyData();
 
         self::assertSame('', $signature->hash());
-        self::assertSame('', $signature->toString());
+        self::assertSame('', (string) $signature);
     }
 
     /**
@@ -29,13 +29,13 @@ final class SignatureTest extends TestCase
      *
      * @covers ::__construct
      * @covers ::hash
-     * @covers ::toString
+     * @covers ::__toString
      */
     public function hashShouldReturnTheHash(): void
     {
         $signature = new Signature('test', 'encoded');
 
         self::assertSame('test', $signature->hash());
-        self::assertSame('encoded', $signature->toString());
+        self::assertSame('encoded', (string) $signature);
     }
 }


### PR DESCRIPTION
I suspect this might have already been suggested but wondered if it would be possible to change the `toString` methods to use the magic method instead? No worries if this idea has already been rejected, just saves a bit of code for a lazy dev like myself :D 