### PR TITLE
Use arrays for audience

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -122,7 +122,7 @@ class Builder
      */
     public function setAudience($audience, $replicateAsHeader = false)
     {
-        return $this->setRegisteredClaim('aud', (string) $audience, $replicateAsHeader);
+        return $this->permittedFor($audience, $replicateAsHeader);
     }
 
     /**

--- a/src/Claim/Factory.php
+++ b/src/Claim/Factory.php
@@ -10,7 +10,9 @@ namespace Lcobucci\JWT\Claim;
 use DateTimeImmutable;
 use Lcobucci\JWT\Claim;
 use Lcobucci\JWT\Token\RegisteredClaims;
+use function current;
 use function in_array;
+use function is_array;
 
 /**
  * Class that create claims
@@ -62,6 +64,10 @@ class Factory
     {
         if ($value instanceof DateTimeImmutable && in_array($name, RegisteredClaims::DATE_CLAIMS, true)) {
             $value = $value->getTimestamp();
+        }
+
+        if ($name === RegisteredClaims::AUDIENCE && is_array($value)) {
+            $value = current($value);
         }
 
         if (!empty($this->callbacks[$name])) {

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -17,6 +17,7 @@ use Lcobucci\JWT\Token\RegisteredClaims;
 use Lcobucci\JWT\Token\UnsupportedHeaderFound;
 use RuntimeException;
 use function array_key_exists;
+use function is_array;
 
 /**
  * This class parses the JWT strings and convert them into tokens
@@ -119,7 +120,7 @@ class Parser
             throw UnsupportedHeaderFound::encryption();
         }
 
-        return $this->convertToDateObjects($header);
+        return $this->convertItems($header);
     }
 
     /**
@@ -133,7 +134,7 @@ class Parser
     {
         $claims = (array) $this->decoder->jsonDecode($this->decoder->base64UrlDecode($data));
 
-        return $this->convertToDateObjects($claims);
+        return $this->convertItems($claims);
     }
 
     /**
@@ -141,7 +142,7 @@ class Parser
      *
      * @return array<string, mixed>
      */
-    private function convertToDateObjects(array $items)
+    private function convertItems(array $items)
     {
         foreach (RegisteredClaims::DATE_CLAIMS as $name) {
             if (! array_key_exists($name, $items)) {
@@ -149,6 +150,10 @@ class Parser
             }
 
             $items[$name] = new DateTimeImmutable('@' . ((int) $items[$name]));
+        }
+
+        if (array_key_exists(RegisteredClaims::AUDIENCE, $items) && ! is_array($items[RegisteredClaims::AUDIENCE])) {
+            $items[RegisteredClaims::AUDIENCE] = [$items[RegisteredClaims::AUDIENCE]];
         }
 
         return $items;

--- a/src/Token.php
+++ b/src/Token.php
@@ -16,8 +16,10 @@ use Lcobucci\JWT\Signer\Key;
 use Lcobucci\JWT\Token\DataSet;
 use Lcobucci\JWT\Token\RegisteredClaims;
 use OutOfBoundsException;
+use function current;
 use function func_num_args;
 use function in_array;
+use function is_array;
 use function sprintf;
 
 /**
@@ -238,6 +240,10 @@ class Token
 
         if ($value instanceof DateTimeImmutable && in_array($name, RegisteredClaims::DATE_CLAIMS, true)) {
             return $value->getTimestamp();
+        }
+
+        if ($name === RegisteredClaims::AUDIENCE && is_array($value)) {
+            return current($value);
         }
 
         return $value;

--- a/src/Token.php
+++ b/src/Token.php
@@ -237,7 +237,7 @@ class Token
         }
 
         if ($value instanceof DateTimeImmutable && in_array($name, RegisteredClaims::DATE_CLAIMS, true)) {
-            $value = $value->getTimestamp();
+            return $value->getTimestamp();
         }
 
         return $value;

--- a/test/functional/CompatibilityLayerTest.php
+++ b/test/functional/CompatibilityLayerTest.php
@@ -65,18 +65,21 @@ final class CompatibilityLayerTest extends TestCase
 
         $token = $config->builder()
             ->issuedAt($now)
+            ->permittedFor('test')
             ->canOnlyBeUsedAfter($now + 5)
             ->expiresAt($now + 3600)
             ->getToken($config->signer(), $config->signingKey());
 
         $expectedNow = new DateTimeImmutable('@' . $now);
 
+        self::assertSame(['test'], $token->claims()->get('aud'));
         self::assertEquals($expectedNow, $token->claims()->get('iat'));
         self::assertEquals($expectedNow->modify('+5 seconds'), $token->claims()->get('nbf'));
         self::assertEquals($expectedNow->modify('+1 hour'), $token->claims()->get('exp'));
 
         $token2 = $config->parser()->parse($token->toString());
 
+        self::assertSame(['test'], $token2->claims()->get('aud'));
         self::assertEquals($expectedNow, $token2->claims()->get('iat'));
         self::assertEquals($expectedNow->modify('+5 seconds'), $token2->claims()->get('nbf'));
         self::assertEquals($expectedNow->modify('+1 hour'), $token2->claims()->get('exp'));

--- a/test/unit/BuilderTest.php
+++ b/test/unit/BuilderTest.php
@@ -62,7 +62,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @covers ::setRegisteredClaim
      * @covers ::configureClaim
      * @covers ::createSignature
-     * @covers ::convertDatesToInt
+     * @covers ::convertItems
      *
      * @uses \Lcobucci\JWT\Builder::getToken
      */
@@ -85,7 +85,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @covers ::setRegisteredClaim
      * @covers ::configureClaim
      * @covers ::createSignature
-     * @covers ::convertDatesToInt
+     * @covers ::convertItems
      *
      * @uses \Lcobucci\JWT\Builder::getToken
      */
@@ -124,7 +124,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @covers ::configureClaim
      * @covers ::createSignature
      * @covers ::convertToDate
-     * @covers ::convertDatesToInt
+     * @covers ::convertItems
      *
      * @uses \Lcobucci\JWT\Builder::getToken
      */
@@ -149,7 +149,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @covers ::createSignature
      * @covers ::convertToDate
      * @covers ::convertToDate
-     * @covers ::convertDatesToInt
+     * @covers ::convertItems
      *
      * @uses \Lcobucci\JWT\Builder::getToken
      */
@@ -188,7 +188,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @covers ::setRegisteredClaim
      * @covers ::configureClaim
      * @covers ::createSignature
-     * @covers ::convertDatesToInt
+     * @covers ::convertItems
      *
      * @uses \Lcobucci\JWT\Builder::getToken
      */
@@ -211,7 +211,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @covers ::setRegisteredClaim
      * @covers ::configureClaim
      * @covers ::createSignature
-     * @covers ::convertDatesToInt
+     * @covers ::convertItems
      *
      * @uses \Lcobucci\JWT\Builder::getToken
      */
@@ -250,7 +250,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @covers ::configureClaim
      * @covers ::createSignature
      * @covers ::convertToDate
-     * @covers ::convertDatesToInt
+     * @covers ::convertItems
      *
      * @uses \Lcobucci\JWT\Builder::getToken
      */
@@ -274,7 +274,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @covers ::configureClaim
      * @covers ::createSignature
      * @covers ::convertToDate
-     * @covers ::convertDatesToInt
+     * @covers ::convertItems
      *
      * @uses \Lcobucci\JWT\Builder::getToken
      */
@@ -313,7 +313,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @covers ::setRegisteredClaim
      * @covers ::configureClaim
      * @covers ::createSignature
-     * @covers ::convertDatesToInt
+     * @covers ::convertItems
      *
      * @uses \Lcobucci\JWT\Builder::getToken
      */
@@ -336,7 +336,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @covers ::setRegisteredClaim
      * @covers ::configureClaim
      * @covers ::createSignature
-     * @covers ::convertDatesToInt
+     * @covers ::convertItems
      *
      * @uses \Lcobucci\JWT\Builder::getToken
      */
@@ -375,7 +375,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @covers ::configureClaim
      * @covers ::createSignature
      * @covers ::convertToDate
-     * @covers ::convertDatesToInt
+     * @covers ::convertItems
      *
      * @uses \Lcobucci\JWT\Builder::getToken
      */
@@ -399,7 +399,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @covers ::configureClaim
      * @covers ::createSignature
      * @covers ::convertToDate
-     * @covers ::convertDatesToInt
+     * @covers ::convertItems
      *
      * @uses \Lcobucci\JWT\Builder::getToken
      */
@@ -438,7 +438,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @covers ::setRegisteredClaim
      * @covers ::configureClaim
      * @covers ::createSignature
-     * @covers ::convertDatesToInt
+     * @covers ::convertItems
      *
      * @uses \Lcobucci\JWT\Builder::getToken
      */
@@ -461,7 +461,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @covers ::setRegisteredClaim
      * @covers ::configureClaim
      * @covers ::createSignature
-     * @covers ::convertDatesToInt
+     * @covers ::convertItems
      *
      * @uses \Lcobucci\JWT\Builder::getToken
      */
@@ -498,7 +498,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @covers ::withClaim
      * @covers ::configureClaim
      * @covers ::createSignature
-     * @covers ::convertDatesToInt
+     * @covers ::convertItems
      *
      * @uses \Lcobucci\JWT\Builder::getToken
      */
@@ -547,7 +547,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @covers ::__construct
      * @covers ::withHeader
      * @covers ::createSignature
-     * @covers ::convertDatesToInt
+     * @covers ::convertItems
      *
      * @uses \Lcobucci\JWT\Builder::getToken
      */
@@ -581,7 +581,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      * @covers ::__construct
      * @covers ::sign
      * @covers ::createSignature
-     * @covers ::convertDatesToInt
+     * @covers ::convertItems
      *
      * @uses \Lcobucci\JWT\Builder::getToken
      */
@@ -644,7 +644,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
      *
      * @covers ::getToken
      * @covers ::createSignature
-     * @covers ::convertDatesToInt
+     * @covers ::convertItems
      *
      * @uses \Lcobucci\JWT\Builder::__construct
      * @uses \Lcobucci\JWT\Builder::configureClaim

--- a/test/unit/ParserTest.php
+++ b/test/unit/ParserTest.php
@@ -140,7 +140,7 @@ class ParserTest extends \PHPUnit\Framework\TestCase
      * @covers Lcobucci\JWT\Parser::parseHeader
      * @covers Lcobucci\JWT\Parser::parseClaims
      * @covers Lcobucci\JWT\Parser::parseSignature
-     * @covers Lcobucci\JWT\Parser::convertToDateObjects
+     * @covers Lcobucci\JWT\Parser::convertItems
      * @covers \Lcobucci\JWT\Claim\Factory
      * @covers \Lcobucci\JWT\Claim\Basic
      * @covers \Lcobucci\JWT\Claim\EqualsTo
@@ -175,7 +175,7 @@ class ParserTest extends \PHPUnit\Framework\TestCase
      * @covers Lcobucci\JWT\Parser::parseHeader
      * @covers Lcobucci\JWT\Parser::parseClaims
      * @covers Lcobucci\JWT\Parser::parseSignature
-     * @covers Lcobucci\JWT\Parser::convertToDateObjects
+     * @covers Lcobucci\JWT\Parser::convertItems
      * @covers \Lcobucci\JWT\Claim\Factory
      * @covers \Lcobucci\JWT\Claim\Basic
      * @covers \Lcobucci\JWT\Claim\EqualsTo
@@ -214,7 +214,7 @@ class ParserTest extends \PHPUnit\Framework\TestCase
      * @covers Lcobucci\JWT\Parser::parseHeader
      * @covers Lcobucci\JWT\Parser::parseClaims
      * @covers Lcobucci\JWT\Parser::parseSignature
-     * @covers Lcobucci\JWT\Parser::convertToDateObjects
+     * @covers Lcobucci\JWT\Parser::convertItems
      * @covers \Lcobucci\JWT\Claim\Factory
      * @covers \Lcobucci\JWT\Claim\Basic
      * @covers \Lcobucci\JWT\Claim\EqualsTo


### PR DESCRIPTION
When using the new API the `aud` is always an array, we should then behave consistently.