### PR TITLE
Fix validation of the audience claim on the new API

### DIFF
--- a/src/Token.php
+++ b/src/Token.php
@@ -308,7 +308,7 @@ class Token
      */
     public function isPermittedFor($audience)
     {
-        return $this->claims->get(RegisteredClaims::AUDIENCE) === $audience;
+        return in_array($audience, $this->claims->get(RegisteredClaims::AUDIENCE, []), true);
     }
 
     /**

--- a/test/unit/TokenTest.php
+++ b/test/unit/TokenTest.php
@@ -536,7 +536,7 @@ class TokenTest extends \PHPUnit\Framework\TestCase
     {
         $token = new Token(
             [],
-            [RegisteredClaims::AUDIENCE => 'test']
+            [RegisteredClaims::AUDIENCE => ['test']]
         );
 
         self::assertFalse($token->isPermittedFor('testing'));
@@ -554,7 +554,7 @@ class TokenTest extends \PHPUnit\Framework\TestCase
     {
         $token = new Token(
             [],
-            [RegisteredClaims::AUDIENCE => 10]
+            [RegisteredClaims::AUDIENCE => [10]]
         );
 
         self::assertFalse($token->isPermittedFor('10'));
@@ -572,7 +572,7 @@ class TokenTest extends \PHPUnit\Framework\TestCase
     {
         $token = new Token(
             [],
-            [RegisteredClaims::AUDIENCE => 'testing']
+            [RegisteredClaims::AUDIENCE => ['testing']]
         );
 
         self::assertTrue($token->isPermittedFor('testing'));

--- a/test/unit/Validation/Constraint/PermittedForTest.php
+++ b/test/unit/Validation/Constraint/PermittedForTest.php
@@ -42,7 +42,7 @@ final class PermittedForTest extends ConstraintTestCase
         $this->expectExceptionMessage('The token is not allowed to be used by this audience');
 
         $constraint = new PermittedFor('test.com');
-        $constraint->assert($this->buildToken([RegisteredClaims::AUDIENCE => 'aa.com']));
+        $constraint->assert($this->buildToken([RegisteredClaims::AUDIENCE => ['aa.com']]));
     }
 
     /**
@@ -57,7 +57,7 @@ final class PermittedForTest extends ConstraintTestCase
         $this->expectExceptionMessage('The token is not allowed to be used by this audience');
 
         $constraint = new PermittedFor('123');
-        $constraint->assert($this->buildToken([RegisteredClaims::AUDIENCE => 123]));
+        $constraint->assert($this->buildToken([RegisteredClaims::AUDIENCE => [123]]));
     }
 
     /**
@@ -68,7 +68,7 @@ final class PermittedForTest extends ConstraintTestCase
      */
     public function assertShouldNotRaiseExceptionWhenAudienceMatches()
     {
-        $token      = $this->buildToken([RegisteredClaims::AUDIENCE => 'test.com']);
+        $token      = $this->buildToken([RegisteredClaims::AUDIENCE => ['test.com']]);
         $constraint = new PermittedFor('test.com');
 
         $constraint->assert($token);


### PR DESCRIPTION
As described in #560 our jwt audience contains an array with a single element which breaks the validation