### PR TITLE
Prefer ext-sodium cache-timing-safe functions

### DIFF
--- a/src/Encoding/CannotDecodeContent.php
+++ b/src/Encoding/CannotDecodeContent.php
@@ -6,6 +6,7 @@ namespace Lcobucci\JWT\Encoding;
 use JsonException;
 use Lcobucci\JWT\Exception;
 use RuntimeException;
+use SodiumException;
 
 final class CannotDecodeContent extends RuntimeException implements Exception
 {
@@ -14,8 +15,8 @@ final class CannotDecodeContent extends RuntimeException implements Exception
         return new self('Error while decoding from JSON', 0, $previous);
     }
 
-    public static function invalidBase64String(): self
+    public static function invalidBase64String(SodiumException $sodiumException): self
     {
-        return new self('Error while decoding from Base64Url, invalid base64 characters detected');
+        return new self('Error while decoding from Base64Url, invalid base64 characters detected', 0, $sodiumException);
     }
 }

--- a/src/Encoding/JoseEncoder.php
+++ b/src/Encoding/JoseEncoder.php
@@ -55,7 +55,7 @@ final class JoseEncoder implements Encoder, Decoder
         try {
             return sodium_base642bin($data, SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING, '');
         } catch (SodiumException $sodiumException) {
-            throw CannotDecodeContent::invalidBase64String();
+            throw CannotDecodeContent::invalidBase64String($sodiumException);
         }
     }
 }

--- a/src/Signer/Key/InMemory.php
+++ b/src/Signer/Key/InMemory.php
@@ -41,7 +41,7 @@ final class InMemory implements Key
         try {
             $decoded = sodium_base642bin($contents, SODIUM_BASE64_VARIANT_ORIGINAL, '');
         } catch (SodiumException $sodiumException) {
-            throw CannotDecodeContent::invalidBase64String();
+            throw CannotDecodeContent::invalidBase64String($sodiumException);
         }
 
         return new self($decoded, $passphrase);

--- a/src/Signer/Key/InMemory.php
+++ b/src/Signer/Key/InMemory.php
@@ -5,12 +5,15 @@ namespace Lcobucci\JWT\Signer\Key;
 
 use Lcobucci\JWT\Encoding\CannotDecodeContent;
 use Lcobucci\JWT\Signer\Key;
+use SodiumException;
 use SplFileObject;
 use Throwable;
 
 use function assert;
-use function base64_decode;
 use function is_string;
+use function sodium_base642bin;
+
+use const SODIUM_BASE64_VARIANT_ORIGINAL;
 
 final class InMemory implements Key
 {
@@ -35,9 +38,9 @@ final class InMemory implements Key
 
     public static function base64Encoded(string $contents, string $passphrase = ''): self
     {
-        $decoded = base64_decode($contents, true);
-
-        if ($decoded === false) {
+        try {
+            $decoded = sodium_base642bin($contents, SODIUM_BASE64_VARIANT_ORIGINAL, '');
+        } catch (SodiumException $sodiumException) {
             throw CannotDecodeContent::invalidBase64String();
         }
 

--- a/test/performance/Hmac/HmacBench.php
+++ b/test/performance/Hmac/HmacBench.php
@@ -11,7 +11,7 @@ use PhpBench\Benchmark\Metadata\Annotations\Groups;
 /** @Groups({"Hmac"}) */
 abstract class HmacBench extends SignerBench
 {
-    private const ENCODED_KEY = 'hJtXIZ2uSN5kbQfbtTNWbpdmhkV8FJG+Onbc6mxCcYg';
+    private const ENCODED_KEY = 'hJtXIZ2uSN5kbQfbtTNWbpdmhkV8FJG+Onbc6mxCcYg=';
 
     protected function signingKey(): Key
     {

--- a/test/unit/Encoding/JoseEncoderTest.php
+++ b/test/unit/Encoding/JoseEncoderTest.php
@@ -148,7 +148,7 @@ final class JoseEncoderTest extends TestCase
         $this->expectExceptionCode(0);
         $this->expectExceptionMessage('Error while decoding from Base64Url, invalid base64 characters detected');
 
-        $decoder->base64UrlDecode('áááááá');
+        $decoder->base64UrlDecode('ááá');
     }
 
     /**


### PR DESCRIPTION
Since from #605 `ext-sodium` is required, we can now leverage it