### PR TITLE
Add missing claims method definition to Token interface

### DIFF
--- a/src/Token.php
+++ b/src/Token.php
@@ -14,6 +14,11 @@ interface Token
     public function headers(): DataSet;
 
     /**
+     * Returns the token claims
+     */
+    public function claims(): DataSet;
+
+    /**
      * Returns if the token is allowed to be used by the audience
      */
     public function isPermittedFor(string $audience): bool;


### PR DESCRIPTION
I've noticed that the Token interface is missing the definition of the claims method. 