### PR TITLE
Encode timestamps as float instead of string

### DIFF
--- a/src/Encoding/MicrosecondBasedDateConversion.php
+++ b/src/Encoding/MicrosecondBasedDateConversion.php
@@ -8,6 +8,7 @@ use Lcobucci\JWT\ClaimsFormatter;
 use Lcobucci\JWT\Token\RegisteredClaims;
 
 use function array_key_exists;
+use function floatval;
 
 final class MicrosecondBasedDateConversion implements ClaimsFormatter
 {
@@ -25,7 +26,7 @@ final class MicrosecondBasedDateConversion implements ClaimsFormatter
         return $claims;
     }
 
-    /** @return int|string */
+    /** @return int|float */
     private function convertDate(DateTimeImmutable $date)
     {
         $seconds      = $date->format('U');
@@ -35,6 +36,6 @@ final class MicrosecondBasedDateConversion implements ClaimsFormatter
             return (int) $seconds;
         }
 
-        return $seconds . '.' . $microseconds;
+        return floatval($seconds . '.' . $microseconds);
     }
 }

--- a/test/unit/Encoding/ChainedFormatterTest.php
+++ b/test/unit/Encoding/ChainedFormatterTest.php
@@ -34,6 +34,6 @@ final class ChainedFormatterTest extends TestCase
         $formatted = $formatter->formatClaims($claims);
 
         self::assertSame('test', $formatted[RegisteredClaims::AUDIENCE]);
-        self::assertSame('1487285080.123456', $formatted[RegisteredClaims::EXPIRATION_TIME]);
+        self::assertSame(1487285080.123456, $formatted[RegisteredClaims::EXPIRATION_TIME]);
     }
 }

--- a/test/unit/Encoding/MicrosecondBasedDateConversionTest.php
+++ b/test/unit/Encoding/MicrosecondBasedDateConversionTest.php
@@ -36,8 +36,8 @@ final class MicrosecondBasedDateConversionTest extends TestCase
         $formatted = $formatter->formatClaims($claims);
 
         self::assertSame(1487285080, $formatted[RegisteredClaims::ISSUED_AT]);
-        self::assertSame('1487285080.000123', $formatted[RegisteredClaims::NOT_BEFORE]);
-        self::assertSame('1487285080.123456', $formatted[RegisteredClaims::EXPIRATION_TIME]);
+        self::assertSame(1487285080.000123, $formatted[RegisteredClaims::NOT_BEFORE]);
+        self::assertSame(1487285080.123456, $formatted[RegisteredClaims::EXPIRATION_TIME]);
         self::assertSame('test', $formatted['testing']); // this should remain untouched
     }
 
@@ -62,7 +62,7 @@ final class MicrosecondBasedDateConversionTest extends TestCase
         $formatted = $formatter->formatClaims($claims);
 
         self::assertSame(1487285080, $formatted[RegisteredClaims::ISSUED_AT]);
-        self::assertSame('1487285080.123456', $formatted[RegisteredClaims::EXPIRATION_TIME]);
+        self::assertSame(1487285080.123456, $formatted[RegisteredClaims::EXPIRATION_TIME]);
         self::assertSame('test', $formatted['testing']); // this should remain untouched
     }
 }


### PR DESCRIPTION
Currently all timestamps are rendered as strings.
Some JWT parsers like auth0/node-jsonwebtoken and [jwt.io](https://jwt.io) complain about timestamps formatted as a string. This PR changes this to encode timestamps as float instead of string values.