### PR TITLE
Changed string return type to float according to JWT specs

### DIFF
--- a/src/Encoding/MicrosecondBasedDateConversion.php
+++ b/src/Encoding/MicrosecondBasedDateConversion.php
@@ -25,7 +25,7 @@ final class MicrosecondBasedDateConversion implements ClaimsFormatter
         return $claims;
     }
 
-    /** @return int|string */
+    /** @return int|float */
     private function convertDate(DateTimeImmutable $date)
     {
         $seconds      = $date->format('U');
@@ -35,6 +35,6 @@ final class MicrosecondBasedDateConversion implements ClaimsFormatter
             return (int) $seconds;
         }
 
-        return $seconds . '.' . $microseconds;
+        return (float) ($seconds . '.' . $microseconds);
     }
 }


### PR DESCRIPTION
NumericDate of `exp` and `iat` claims do not respect JWT specifications as of here
`exp`: https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-32#section-4.1.4
`iat`: https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-32#section-4.1.6

both says
> [...] Its value MUST be a number containing a NumericDate value.  [...]

but `MicrosecondBasedDateConversion`'s `convertDate` method returns a string instead of a number.

`return $seconds . '.' . $microseconds;`

Fixed it casting the string to a **float**:

`return (float) ($seconds . '.' . $microseconds);`