### PR TITLE
Fix forward compatibility layer gap for audience claim 

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -151,6 +151,87 @@ Here's the migration:
 +    ->getToken($config->signer(), $config->signingKey());
 ```
 
+#### Support for multiple audiences
+
+Even though we didn't officially support multiple audiences, it was technically possible to achieve that by manually setting the `aud` claim.
+
+For this case, there are different approaches to migrate your code.
+Feel free to choose your preferred one.
+
+##### Multiple calls to `Builder#permittedFor()`
+
+```diff
+ <?php
+ declare(strict_types=1);
+ 
+ namespace Me\MyApp\Authentication;
+
+-use Lcobucci\JWT\Builder;
++use Lcobucci\JWT\Configuration;
++use Lcobucci\JWT\Signer\Key\InMemory;
+ use Lcobucci\JWT\Signer\Hmac\Sha256;
+
++$config = Configuration::forSymmetricSigner(new Sha256(), InMemory::plainText('testing'));
+
+-$token = (new Builder())
++$token = $config->builder()
+-    ->withClaim('aud', ['one', 'two', 'three'])
++    ->permittedFor('one')
++    ->permittedFor('two')
++    ->permittedFor('three')
+-    ->sign(new Sha256(), 'testing')
+-    ->getToken();
++    ->getToken($config->signer(), $config->signingKey());
+```
+
+##### Single call to `Builder#permittedFor()` with multiple arguments
+
+```diff
+ <?php
+ declare(strict_types=1);
+ 
+ namespace Me\MyApp\Authentication;
+
+-use Lcobucci\JWT\Builder;
++use Lcobucci\JWT\Configuration;
++use Lcobucci\JWT\Signer\Key\InMemory;
+ use Lcobucci\JWT\Signer\Hmac\Sha256;
+
++$config = Configuration::forSymmetricSigner(new Sha256(), InMemory::plainText('testing'));
+
+-$token = (new Builder())
++$token = $config->builder()
+-    ->withClaim('aud', ['one', 'two', 'three'])
++    ->permittedFor('one', 'two', 'three')
+-    ->sign(new Sha256(), 'testing')
+-    ->getToken();
++    ->getToken($config->signer(), $config->signingKey());
+```
+
+##### Single call to `Builder#permittedFor()` with argument unpacking
+
+```diff
+ <?php
+ declare(strict_types=1);
+ 
+ namespace Me\MyApp\Authentication;
+
+-use Lcobucci\JWT\Builder;
++use Lcobucci\JWT\Configuration;
++use Lcobucci\JWT\Signer\Key\InMemory;
+ use Lcobucci\JWT\Signer\Hmac\Sha256;
+
++$config = Configuration::forSymmetricSigner(new Sha256(), InMemory::plainText('testing'));
+
+-$token = (new Builder())
++$token = $config->builder()
+-    ->withClaim('aud', ['one', 'two', 'three'])
++    ->permittedFor(...['one', 'two', 'three'])
+-    ->sign(new Sha256(), 'testing')
+-    ->getToken();
++    ->getToken($config->signer(), $config->signingKey());
+```
+
 ### Replace `Token#verify()` and `Token#validate()` with Validation API
 
 These methods were quite limited and brings multiple responsibilities to the `Token` class.

--- a/test/unit/TokenTest.php
+++ b/test/unit/TokenTest.php
@@ -512,6 +512,37 @@ class TokenTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      *
+     * @uses \Lcobucci\JWT\Token::__construct
+     * @uses \Lcobucci\JWT\Token::convertToDataSet
+     * @uses \Lcobucci\JWT\ValidationData
+     * @uses \Lcobucci\JWT\Claim\Basic
+     * @uses \Lcobucci\JWT\Claim\EqualsTo
+     *
+     * @covers ::validate
+     * @covers ::getClaims
+     * @covers ::getValidatableClaims
+     */
+    public function onlyFirstAudienceShouldBeUsedOnLegacyValidation()
+    {
+        $token = new Token(
+            [],
+            ['aud' => ['one', 'two']]
+        );
+
+        $data = new ValidationData();
+        $data->setAudience('one');
+
+        self::assertTrue($token->validate($data));
+
+        $data = new ValidationData();
+        $data->setAudience('two');
+
+        self::assertFalse($token->validate($data));
+    }
+
+    /**
+     * @test
+     *
      * @covers ::isPermittedFor
      *
      * @uses \Lcobucci\JWT\Token::__construct


### PR DESCRIPTION
When backporting the v4's API we wrongly decided to preserve the lack of support to multiple audiences.

The problem with that decision is that it makes the FC-layer not totally compatible with the future, making it harder for users to properly migrate their code.

Even though it wasn't officially supported, users could configure multiple audiences using the method `Builder#set()` or
`Builder#withClaim()`.

This backports the support for multiple audiences whilst maintaining the deprecated functionality of replicating headers.