### PR TITLE
Support composer classmap-authoritative option

### DIFF
--- a/compat/class-aliases.php
+++ b/compat/class-aliases.php
@@ -1,5 +1,4 @@
 <?php
 
-class_exists(\Lcobucci\JWT\Token\Plain::class);
-class_exists(\Lcobucci\JWT\Token\Signature::class);
-
+class_exists(\Lcobucci\JWT\Token\Plain::class, false) || class_alias(\Lcobucci\JWT\Token::class, \Lcobucci\JWT\Token\Plain::class);
+class_exists(\Lcobucci\JWT\Token\Signature::class, false) || class_alias(\Lcobucci\JWT\Signature::class, \Lcobucci\JWT\Token\Signature::class);

--- a/src/Token/Plain.php
+++ b/src/Token/Plain.php
@@ -5,4 +5,4 @@ namespace Lcobucci\JWT\Token;
 use Lcobucci\JWT\Token;
 use function class_alias;
 
-class_alias(Token::class, Plain::class);
+class_exists(Plain::class, false) || class_alias(Token::class, Plain::class);

--- a/src/Token/Signature.php
+++ b/src/Token/Signature.php
@@ -5,4 +5,4 @@ namespace Lcobucci\JWT\Token;
 use Lcobucci\JWT\Signature as SignatureImpl;
 use function class_alias;
 
-class_alias(SignatureImpl::class, Signature::class);
+class_exists(Signature::class, false) || class_alias(SignatureImpl::class, Signature::class);


### PR DESCRIPTION
Fix #666 
Forcibly calls `class_alias()` when `class_exists()` autoload feature fails due to composer `classmap-authoritative` option being enabled.