### PR TITLE
Fix compatibility issues with older libsodium version (< 1.0.14)

### DIFF
--- a/infection.json.dist
+++ b/infection.json.dist
@@ -32,6 +32,11 @@
                 "Lcobucci\\JWT\\Signer\\Ecdsa\\MultibyteStringConverter::preparePositiveInteger"
             ]
         },
+        "LogicalNot": {
+            "ignoreSourceCodeByRegex": [
+                "if \\(!function_exists\\('sodium_\\w+'\\)\\) \\{"
+            ]
+        },
         "MBString": {
             "ignore": [
                 "Lcobucci\\JWT\\Signer\\Ecdsa\\MultibyteStringConverter"

--- a/src/Encoding/CannotDecodeContent.php
+++ b/src/Encoding/CannotDecodeContent.php
@@ -6,7 +6,6 @@ namespace Lcobucci\JWT\Encoding;
 use JsonException;
 use Lcobucci\JWT\Exception;
 use RuntimeException;
-use SodiumException;
 
 final class CannotDecodeContent extends RuntimeException implements Exception
 {
@@ -15,8 +14,8 @@ final class CannotDecodeContent extends RuntimeException implements Exception
         return new self('Error while decoding from JSON', 0, $previous);
     }
 
-    public static function invalidBase64String(SodiumException $sodiumException): self
+    public static function invalidBase64String(): self
     {
-        return new self('Error while decoding from Base64Url, invalid base64 characters detected', 0, $sodiumException);
+        return new self('Error while decoding from Base64Url, invalid base64 characters detected');
     }
 }

--- a/src/Encoding/JoseEncoder.php
+++ b/src/Encoding/JoseEncoder.php
@@ -6,17 +6,14 @@ namespace Lcobucci\JWT\Encoding;
 use JsonException;
 use Lcobucci\JWT\Decoder;
 use Lcobucci\JWT\Encoder;
-use SodiumException;
+use Lcobucci\JWT\SodiumBase64Polyfill;
 
 use function json_decode;
 use function json_encode;
-use function sodium_base642bin;
-use function sodium_bin2base64;
 
 use const JSON_THROW_ON_ERROR;
 use const JSON_UNESCAPED_SLASHES;
 use const JSON_UNESCAPED_UNICODE;
-use const SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING;
 
 /**
  * A utilitarian class that encodes and decodes data according with JOSE specifications
@@ -47,15 +44,17 @@ final class JoseEncoder implements Encoder, Decoder
 
     public function base64UrlEncode(string $data): string
     {
-        return sodium_bin2base64($data, SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING);
+        return SodiumBase64Polyfill::bin2base64(
+            $data,
+            SodiumBase64Polyfill::SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING
+        );
     }
 
     public function base64UrlDecode(string $data): string
     {
-        try {
-            return sodium_base642bin($data, SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING, '');
-        } catch (SodiumException $sodiumException) {
-            throw CannotDecodeContent::invalidBase64String($sodiumException);
-        }
+        return SodiumBase64Polyfill::base642bin(
+            $data,
+            SodiumBase64Polyfill::SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING
+        );
     }
 }

--- a/src/Signer/Key/InMemory.php
+++ b/src/Signer/Key/InMemory.php
@@ -3,17 +3,13 @@ declare(strict_types=1);
 
 namespace Lcobucci\JWT\Signer\Key;
 
-use Lcobucci\JWT\Encoding\CannotDecodeContent;
 use Lcobucci\JWT\Signer\Key;
-use SodiumException;
+use Lcobucci\JWT\SodiumBase64Polyfill;
 use SplFileObject;
 use Throwable;
 
 use function assert;
 use function is_string;
-use function sodium_base642bin;
-
-use const SODIUM_BASE64_VARIANT_ORIGINAL;
 
 final class InMemory implements Key
 {
@@ -38,11 +34,10 @@ final class InMemory implements Key
 
     public static function base64Encoded(string $contents, string $passphrase = ''): self
     {
-        try {
-            $decoded = sodium_base642bin($contents, SODIUM_BASE64_VARIANT_ORIGINAL, '');
-        } catch (SodiumException $sodiumException) {
-            throw CannotDecodeContent::invalidBase64String($sodiumException);
-        }
+        $decoded = SodiumBase64Polyfill::base642bin(
+            $contents,
+            SodiumBase64Polyfill::SODIUM_BASE64_VARIANT_ORIGINAL
+        );
 
         return new self($decoded, $passphrase);
     }

--- a/src/SodiumBase64Polyfill.php
+++ b/src/SodiumBase64Polyfill.php
@@ -1,0 +1,88 @@
+<?php
+declare(strict_types=1);
+
+namespace Lcobucci\JWT;
+
+use Lcobucci\JWT\Encoding\CannotDecodeContent;
+use SodiumException;
+
+use function base64_decode;
+use function base64_encode;
+use function function_exists;
+use function is_string;
+use function rtrim;
+use function sodium_base642bin;
+use function sodium_bin2base64;
+use function strtr;
+
+/** @internal */
+final class SodiumBase64Polyfill
+{
+    public const SODIUM_BASE64_VARIANT_ORIGINAL            = 1;
+    public const SODIUM_BASE64_VARIANT_ORIGINAL_NO_PADDING = 3;
+    public const SODIUM_BASE64_VARIANT_URLSAFE             = 5;
+    public const SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING  = 7;
+
+    public static function bin2base64(string $decoded, int $variant): string
+    {
+        if (! function_exists('sodium_bin2base64')) {
+            return self::bin2base64Fallback($decoded, $variant); // @codeCoverageIgnore
+        }
+
+        return sodium_bin2base64($decoded, $variant);
+    }
+
+    public static function bin2base64Fallback(string $decoded, int $variant): string
+    {
+        $encoded = base64_encode($decoded);
+
+        if (
+            $variant === self::SODIUM_BASE64_VARIANT_URLSAFE
+            || $variant === self::SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING
+        ) {
+            $encoded = strtr($encoded, '+/', '-_');
+        }
+
+        if (
+            $variant === self::SODIUM_BASE64_VARIANT_ORIGINAL_NO_PADDING
+            || $variant === self::SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING
+        ) {
+            $encoded = rtrim($encoded, '=');
+        }
+
+        return $encoded;
+    }
+
+    /** @throws CannotDecodeContent */
+    public static function base642bin(string $encoded, int $variant): string
+    {
+        if (! function_exists('sodium_base642bin')) {
+            return self::bin2base64Fallback($encoded, $variant); // @codeCoverageIgnore
+        }
+
+        try {
+            return sodium_base642bin($encoded, $variant, '');
+        } catch (SodiumException $sodiumException) {
+            throw CannotDecodeContent::invalidBase64String();
+        }
+    }
+
+    /** @throws CannotDecodeContent */
+    public static function base642binFallback(string $encoded, int $variant): string
+    {
+        if (
+            $variant === self::SODIUM_BASE64_VARIANT_URLSAFE
+            || $variant === self::SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING
+        ) {
+            $encoded = strtr($encoded, '-_', '+/');
+        }
+
+        $decoded = base64_decode($encoded, true);
+
+        if (! is_string($decoded)) {
+            throw CannotDecodeContent::invalidBase64String();
+        }
+
+        return $decoded;
+    }
+}

--- a/test/functional/ES512TokenTest.php
+++ b/test/functional/ES512TokenTest.php
@@ -35,6 +35,7 @@ use function assert;
  * @covers \Lcobucci\JWT\Signer\Ecdsa\Sha512
  * @covers \Lcobucci\JWT\Signer\InvalidKeyProvided
  * @covers \Lcobucci\JWT\Signer\OpenSSL
+ * @covers \Lcobucci\JWT\SodiumBase64Polyfill
  * @covers \Lcobucci\JWT\Validation\Validator
  * @covers \Lcobucci\JWT\Validation\RequiredConstraintsViolated
  * @covers \Lcobucci\JWT\Validation\Constraint\SignedWith

--- a/test/functional/EcdsaTokenTest.php
+++ b/test/functional/EcdsaTokenTest.php
@@ -37,6 +37,7 @@ use const PHP_EOL;
  * @covers \Lcobucci\JWT\Signer\Ecdsa\Sha512
  * @covers \Lcobucci\JWT\Signer\InvalidKeyProvided
  * @covers \Lcobucci\JWT\Signer\OpenSSL
+ * @covers \Lcobucci\JWT\SodiumBase64Polyfill
  * @covers \Lcobucci\JWT\Validation\Validator
  * @covers \Lcobucci\JWT\Validation\Constraint\SignedWith
  * @covers \Lcobucci\JWT\Validation\Validator

--- a/test/functional/EddsaTokenTest.php
+++ b/test/functional/EddsaTokenTest.php
@@ -31,6 +31,7 @@ use function assert;
  * @covers \Lcobucci\JWT\Signer\Eddsa
  * @covers \Lcobucci\JWT\Signer\InvalidKeyProvided
  * @covers \Lcobucci\JWT\Signer\OpenSSL
+ * @covers \Lcobucci\JWT\SodiumBase64Polyfill
  * @covers \Lcobucci\JWT\Validation\Validator
  * @covers \Lcobucci\JWT\Validation\Constraint\SignedWith
  * @covers \Lcobucci\JWT\Validation\Validator

--- a/test/functional/HmacTokenTest.php
+++ b/test/functional/HmacTokenTest.php
@@ -29,6 +29,7 @@ use function assert;
  * @covers \Lcobucci\JWT\Signer\Hmac
  * @covers \Lcobucci\JWT\Signer\Hmac\Sha256
  * @covers \Lcobucci\JWT\Signer\Hmac\Sha512
+ * @covers \Lcobucci\JWT\SodiumBase64Polyfill
  * @covers \Lcobucci\JWT\Validation\Validator
  * @covers \Lcobucci\JWT\Validation\RequiredConstraintsViolated
  * @covers \Lcobucci\JWT\Validation\Constraint\SignedWith

--- a/test/functional/MaliciousTamperingPreventionTest.php
+++ b/test/functional/MaliciousTamperingPreventionTest.php
@@ -60,6 +60,7 @@ final class MaliciousTamperingPreventionTest extends TestCase
      * @covers \Lcobucci\JWT\Signer\Hmac
      * @covers \Lcobucci\JWT\Signer\Hmac\Sha256
      * @covers \Lcobucci\JWT\Signer\Hmac\Sha512
+     * @covers \Lcobucci\JWT\SodiumBase64Polyfill
      * @covers \Lcobucci\JWT\Validation\Constraint\SignedWith
      * @covers \Lcobucci\JWT\Validation\Validator
      */

--- a/test/functional/RsaTokenTest.php
+++ b/test/functional/RsaTokenTest.php
@@ -34,6 +34,7 @@ use function assert;
  * @covers \Lcobucci\JWT\Signer\Rsa
  * @covers \Lcobucci\JWT\Signer\Rsa\Sha256
  * @covers \Lcobucci\JWT\Signer\Rsa\Sha512
+ * @covers \Lcobucci\JWT\SodiumBase64Polyfill
  * @covers \Lcobucci\JWT\Validation\Validator
  * @covers \Lcobucci\JWT\Validation\RequiredConstraintsViolated
  * @covers \Lcobucci\JWT\Validation\Constraint\SignedWith

--- a/test/functional/UnsignedTokenTest.php
+++ b/test/functional/UnsignedTokenTest.php
@@ -31,6 +31,7 @@ use function assert;
  * @covers \Lcobucci\JWT\Token\Signature
  * @covers \Lcobucci\JWT\Signer\None
  * @covers \Lcobucci\JWT\Signer\Key\InMemory
+ * @covers \Lcobucci\JWT\SodiumBase64Polyfill
  * @covers \Lcobucci\JWT\Validation\RequiredConstraintsViolated
  * @covers \Lcobucci\JWT\Validation\Validator
  * @covers \Lcobucci\JWT\Validation\Constraint\IssuedBy

--- a/test/unit/Encoding/JoseEncoderTest.php
+++ b/test/unit/Encoding/JoseEncoderTest.php
@@ -103,6 +103,8 @@ final class JoseEncoderTest extends TestCase
      * @test
      *
      * @covers ::base64UrlEncode
+     *
+     * @uses \Lcobucci\JWT\SodiumBase64Polyfill::bin2base64()
      */
     public function base64UrlEncodeMustReturnAUrlSafeBase64(): void
     {
@@ -119,6 +121,8 @@ final class JoseEncoderTest extends TestCase
      * @test
      *
      * @covers ::base64UrlEncode
+     *
+     * @uses \Lcobucci\JWT\SodiumBase64Polyfill::bin2base64()
      */
     public function base64UrlEncodeMustEncodeBilboMessageProperly(): void
     {
@@ -139,6 +143,8 @@ final class JoseEncoderTest extends TestCase
      * @test
      *
      * @covers ::base64UrlDecode
+     *
+     * @uses \Lcobucci\JWT\SodiumBase64Polyfill::base642bin()
      */
     public function base64UrlDecodeMustRaiseExceptionWhenInvalidBase64CharsAreUsed(): void
     {
@@ -155,6 +161,8 @@ final class JoseEncoderTest extends TestCase
      * @test
      *
      * @covers ::base64UrlDecode
+     *
+     * @uses \Lcobucci\JWT\SodiumBase64Polyfill::base642bin()
      */
     public function base64UrlDecodeMustReturnTheRightData(): void
     {
@@ -170,6 +178,8 @@ final class JoseEncoderTest extends TestCase
      * @test
      *
      * @covers ::base64UrlDecode
+     *
+     * @uses \Lcobucci\JWT\SodiumBase64Polyfill::base642bin()
      */
     public function base64UrlDecodeMustDecodeBilboMessageProperly(): void
     {

--- a/test/unit/Signer/EddsaTest.php
+++ b/test/unit/Signer/EddsaTest.php
@@ -107,6 +107,8 @@ final class EddsaTest extends TestCase
      *
      * @uses \Lcobucci\JWT\Encoding\JoseEncoder
      * @uses \Lcobucci\JWT\Signer\Key\InMemory
+     * @uses \Lcobucci\JWT\SodiumBase64Polyfill::base642bin()
+     * @uses \Lcobucci\JWT\SodiumBase64Polyfill::bin2base64()
      */
     public function signatureOfRfcExample(): void
     {
@@ -138,6 +140,7 @@ final class EddsaTest extends TestCase
      *
      * @uses \Lcobucci\JWT\Encoding\JoseEncoder
      * @uses \Lcobucci\JWT\Signer\Key\InMemory
+     * @uses \Lcobucci\JWT\SodiumBase64Polyfill::base642bin()
      */
     public function verificationOfRfcExample(): void
     {

--- a/test/unit/Signer/Key/InMemoryTest.php
+++ b/test/unit/Signer/Key/InMemoryTest.php
@@ -27,6 +27,8 @@ final class InMemoryTest extends TestCase
      *
      * @covers ::base64Encoded
      * @covers \Lcobucci\JWT\Encoding\CannotDecodeContent
+     *
+     * @uses \Lcobucci\JWT\SodiumBase64Polyfill::base642bin()
      */
     public function exceptionShouldBeRaisedWhenInvalidBase64CharsAreUsed(): void
     {
@@ -42,6 +44,8 @@ final class InMemoryTest extends TestCase
      * @covers ::base64Encoded
      * @covers ::__construct
      * @covers ::contents
+     *
+     * @uses \Lcobucci\JWT\SodiumBase64Polyfill::base642bin()
      */
     public function base64EncodedShouldDecodeKeyContents(): void
     {

--- a/test/unit/SodiumBase64PolyfillTest.php
+++ b/test/unit/SodiumBase64PolyfillTest.php
@@ -1,0 +1,139 @@
+<?php
+declare(strict_types=1);
+
+namespace Lcobucci\JWT;
+
+use Lcobucci\JWT\Encoding\CannotDecodeContent;
+use PHPUnit\Framework\TestCase;
+
+use function sodium_base642bin;
+use function sodium_bin2base64;
+
+use const SODIUM_BASE64_VARIANT_ORIGINAL;
+use const SODIUM_BASE64_VARIANT_ORIGINAL_NO_PADDING;
+use const SODIUM_BASE64_VARIANT_URLSAFE;
+use const SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING;
+
+/** @coversDefaultClass \Lcobucci\JWT\SodiumBase64Polyfill */
+final class SodiumBase64PolyfillTest extends TestCase
+{
+    private string $testString;
+
+    protected function setUp(): void
+    {
+        // For proper testing we need a string that can challenge every variant
+        $this->testString = sodium_base642bin('I+o2tVq8ynY=', SODIUM_BASE64_VARIANT_ORIGINAL, '');
+    }
+
+    /**
+     * @test
+     *
+     * @coversNothing
+     */
+    public function constantsMatchExtensionOnes(): void
+    {
+        self::assertSame(
+            SODIUM_BASE64_VARIANT_ORIGINAL,
+            SodiumBase64Polyfill::SODIUM_BASE64_VARIANT_ORIGINAL
+        );
+        self::assertSame(
+            SODIUM_BASE64_VARIANT_ORIGINAL_NO_PADDING,
+            SodiumBase64Polyfill::SODIUM_BASE64_VARIANT_ORIGINAL_NO_PADDING
+        );
+        self::assertSame(
+            SODIUM_BASE64_VARIANT_URLSAFE,
+            SodiumBase64Polyfill::SODIUM_BASE64_VARIANT_URLSAFE
+        );
+        self::assertSame(
+            SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING,
+            SodiumBase64Polyfill::SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider provideVariants
+     *
+     * @covers ::bin2base64
+     * @covers ::bin2base64Fallback
+     */
+    public function bin2base64(int $variant): void
+    {
+        $expected = sodium_bin2base64($this->testString, $variant);
+
+        self::assertSame(
+            $expected,
+            SodiumBase64Polyfill::bin2base64($this->testString, $variant)
+        );
+
+        self::assertSame(
+            $expected,
+            SodiumBase64Polyfill::bin2base64Fallback($this->testString, $variant)
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider provideVariants
+     *
+     * @covers ::base642bin
+     * @covers ::base642binFallback
+     */
+    public function base642binFallback(int $variant): void
+    {
+        self::assertSame(
+            $this->testString,
+            SodiumBase64Polyfill::base642bin(
+                sodium_bin2base64($this->testString, $variant),
+                $variant
+            )
+        );
+
+        self::assertSame(
+            $this->testString,
+            SodiumBase64Polyfill::base642binFallback(
+                sodium_bin2base64($this->testString, $variant),
+                $variant
+            )
+        );
+    }
+
+    /** @return int[][] */
+    public function provideVariants(): array
+    {
+        return [
+            [SODIUM_BASE64_VARIANT_ORIGINAL],
+            [SODIUM_BASE64_VARIANT_ORIGINAL_NO_PADDING],
+            [SODIUM_BASE64_VARIANT_URLSAFE],
+            [SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::base642bin
+     *
+     * @uses \Lcobucci\JWT\Encoding\CannotDecodeContent::invalidBase64String()
+     */
+    public function sodiumBase642BinRaisesExceptionOnInvalidBase64(): void
+    {
+        $this->expectException(CannotDecodeContent::class);
+
+        SodiumBase64Polyfill::base642bin('ááá', SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING);
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::base642binFallback
+     *
+     * @uses \Lcobucci\JWT\Encoding\CannotDecodeContent::invalidBase64String()
+     */
+    public function fallbackBase642BinRaisesExceptionOnInvalidBase64(): void
+    {
+        $this->expectException(CannotDecodeContent::class);
+
+        SodiumBase64Polyfill::base642binFallback('ááá', SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING);
+    }
+}


### PR DESCRIPTION
Fixes #665 

The solution proposed here aims at all the following goals together:

1. Do not let user choose: use the safest implementation available
2. Keep the code simple: the polyfill is not really a polyfill since it's not cache-time-safe resistant, but its simple
3. Test the most without altering CI build
4. Achieve the most code-coverage with the fewest `@codeCoverageIgnore` annotations
5. Keep the 100% mutation score with the fewest `ignore` additions to `infection.json.dist`
6. Do not pollute the global namespace, be compatible with https://github.com/paragonie/sodium_compat
7. Remove dependency from `SodiumException` to avoid polyfilling it