### PR TITLE
Fix usage of non JSON numeric values for time fractions (without having precision issues)

### DIFF
--- a/src/Encoding/MicrosecondBasedDateConversion.php
+++ b/src/Encoding/MicrosecondBasedDateConversion.php
@@ -25,16 +25,13 @@ final class MicrosecondBasedDateConversion implements ClaimsFormatter
         return $claims;
     }
 
-    /** @return int|string */
+    /** @return int|float */
     private function convertDate(DateTimeImmutable $date)
     {
-        $seconds      = $date->format('U');
-        $microseconds = $date->format('u');
-
-        if ((int) $microseconds === 0) {
-            return (int) $seconds;
+        if ($date->format('u') === '000000') {
+            return (int) $date->format('U');
         }
 
-        return $seconds . '.' . $microseconds;
+        return (float) $date->format('U.u');
     }
 }

--- a/src/Token/Parser.php
+++ b/src/Token/Parser.php
@@ -12,7 +12,11 @@ use function array_key_exists;
 use function count;
 use function explode;
 use function is_array;
+use function is_string;
+use function json_encode;
 use function strpos;
+
+use const JSON_THROW_ON_ERROR;
 
 final class Parser implements ParserInterface
 {
@@ -105,7 +109,9 @@ final class Parser implements ParserInterface
                 continue;
             }
 
-            $claims[$claim] = $this->convertDate((string) $claims[$claim]);
+            $date = $claims[$claim];
+
+            $claims[$claim] = $this->convertDate(is_string($date) ? $date : json_encode($date, JSON_THROW_ON_ERROR));
         }
 
         return $claims;

--- a/test/functional/TimeFractionPrecisionTest.php
+++ b/test/functional/TimeFractionPrecisionTest.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types=1);
+
+namespace Lcobucci\JWT\FunctionalTests;
+
+use DateTimeImmutable;
+use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Token\Plain;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Lcobucci\JWT\Configuration
+ * @covers \Lcobucci\JWT\Encoding\JoseEncoder
+ * @covers \Lcobucci\JWT\Encoding\ChainedFormatter
+ * @covers \Lcobucci\JWT\Encoding\MicrosecondBasedDateConversion
+ * @covers \Lcobucci\JWT\Encoding\UnifyAudience
+ * @covers \Lcobucci\JWT\Token\Builder
+ * @covers \Lcobucci\JWT\Token\Parser
+ * @covers \Lcobucci\JWT\Token\Plain
+ * @covers \Lcobucci\JWT\Token\DataSet
+ * @covers \Lcobucci\JWT\Token\Signature
+ * @covers \Lcobucci\JWT\Signer\Key\InMemory
+ * @covers \Lcobucci\JWT\Signer\None
+ * @covers \Lcobucci\JWT\Validation\Validator
+ * @covers \Lcobucci\JWT\Validation\RequiredConstraintsViolated
+ * @covers \Lcobucci\JWT\Validation\Constraint\SignedWith
+ */
+final class TimeFractionPrecisionTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider datesWithPotentialRoundingIssues
+     */
+    public function timeFractionsPrecisionsAreRespected(string $timeFraction): void
+    {
+        $config = Configuration::forUnsecuredSigner();
+
+        $issuedAt = DateTimeImmutable::createFromFormat('U.u', $timeFraction);
+
+        self::assertInstanceOf(DateTimeImmutable::class, $issuedAt);
+        self::assertSame($timeFraction, $issuedAt->format('U.u'));
+
+        $token = $config->builder()
+            ->issuedAt($issuedAt)
+            ->getToken($config->signer(), $config->signingKey());
+
+        $parsedToken = $config->parser()->parse($token->toString());
+
+        self::assertInstanceOf(Plain::class, $parsedToken);
+        self::assertSame($timeFraction, $parsedToken->claims()->get('iat')->format('U.u'));
+    }
+
+    /** @return iterable<string[]> */
+    public function datesWithPotentialRoundingIssues(): iterable
+    {
+        yield ['1613938511.017448'];
+        yield ['1613938511.023691'];
+        yield ['1613938511.018045'];
+        yield ['1616074725.008455'];
+    }
+}

--- a/test/unit/Encoding/ChainedFormatterTest.php
+++ b/test/unit/Encoding/ChainedFormatterTest.php
@@ -34,6 +34,6 @@ final class ChainedFormatterTest extends TestCase
         $formatted = $formatter->formatClaims($claims);
 
         self::assertSame('test', $formatted[RegisteredClaims::AUDIENCE]);
-        self::assertSame('1487285080.123456', $formatted[RegisteredClaims::EXPIRATION_TIME]);
+        self::assertSame(1487285080.123456, $formatted[RegisteredClaims::EXPIRATION_TIME]);
     }
 }

--- a/test/unit/Encoding/MicrosecondBasedDateConversionTest.php
+++ b/test/unit/Encoding/MicrosecondBasedDateConversionTest.php
@@ -36,8 +36,8 @@ final class MicrosecondBasedDateConversionTest extends TestCase
         $formatted = $formatter->formatClaims($claims);
 
         self::assertSame(1487285080, $formatted[RegisteredClaims::ISSUED_AT]);
-        self::assertSame('1487285080.000123', $formatted[RegisteredClaims::NOT_BEFORE]);
-        self::assertSame('1487285080.123456', $formatted[RegisteredClaims::EXPIRATION_TIME]);
+        self::assertSame(1487285080.000123, $formatted[RegisteredClaims::NOT_BEFORE]);
+        self::assertSame(1487285080.123456, $formatted[RegisteredClaims::EXPIRATION_TIME]);
         self::assertSame('test', $formatted['testing']); // this should remain untouched
     }
 
@@ -62,7 +62,7 @@ final class MicrosecondBasedDateConversionTest extends TestCase
         $formatted = $formatter->formatClaims($claims);
 
         self::assertSame(1487285080, $formatted[RegisteredClaims::ISSUED_AT]);
-        self::assertSame('1487285080.123456', $formatted[RegisteredClaims::EXPIRATION_TIME]);
+        self::assertSame(1487285080.123456, $formatted[RegisteredClaims::EXPIRATION_TIME]);
         self::assertSame('test', $formatted['testing']); // this should remain untouched
     }
 }

--- a/test/unit/Token/ParserTest.php
+++ b/test/unit/Token/ParserTest.php
@@ -453,7 +453,7 @@ final class ParserTest extends TestCase
     {
         $data = [
             RegisteredClaims::ISSUED_AT => 1486930663,
-            RegisteredClaims::EXPIRATION_TIME => '1486930757.023055',
+            RegisteredClaims::EXPIRATION_TIME => 1486930757.023055,
         ];
 
         $this->decoder->expects(self::exactly(2))


### PR DESCRIPTION
🖋 The problem of precession of timestamp floats is solved by using a json_encode instead of (string).

This solves the **float round** problem when we encode/parse floats .