### PR TITLE
Prevent type conversions issues when parsing time-fractions

### DIFF
--- a/src/Token/Parser.php
+++ b/src/Token/Parser.php
@@ -12,14 +12,13 @@ use function array_key_exists;
 use function count;
 use function explode;
 use function is_array;
-use function is_string;
-use function json_encode;
-use function strpos;
-
-use const JSON_THROW_ON_ERROR;
+use function is_numeric;
+use function number_format;
 
 final class Parser implements ParserInterface
 {
+    private const MICROSECOND_PRECISION = 6;
+
     private Decoder $decoder;
 
     public function __construct(Decoder $decoder)
@@ -109,25 +108,29 @@ final class Parser implements ParserInterface
                 continue;
             }
 
-            $date = $claims[$claim];
-
-            $claims[$claim] = $this->convertDate(is_string($date) ? $date : json_encode($date, JSON_THROW_ON_ERROR));
+            $claims[$claim] = $this->convertDate($claims[$claim]);
         }
 
         return $claims;
     }
 
-    /** @throws InvalidTokenStructure */
-    private function convertDate(string $value): DateTimeImmutable
+    /**
+     * @param int|float|string $timestamp
+     *
+     * @throws InvalidTokenStructure
+     */
+    private function convertDate($timestamp): DateTimeImmutable
     {
-        if (strpos($value, '.') === false) {
-            return new DateTimeImmutable('@' . $value);
+        if (! is_numeric($timestamp)) {
+            throw InvalidTokenStructure::dateIsNotParseable($timestamp);
         }
 
-        $date = DateTimeImmutable::createFromFormat('U.u', $value);
+        $normalizedTimestamp = number_format((float) $timestamp, self::MICROSECOND_PRECISION, '.', '');
+
+        $date = DateTimeImmutable::createFromFormat('U.u', $normalizedTimestamp);
 
         if ($date === false) {
-            throw InvalidTokenStructure::dateIsNotParseable($value);
+            throw InvalidTokenStructure::dateIsNotParseable($normalizedTimestamp);
         }
 
         return $date;

--- a/test/functional/TimeFractionPrecisionTest.php
+++ b/test/functional/TimeFractionPrecisionTest.php
@@ -5,6 +5,7 @@ namespace Lcobucci\JWT\FunctionalTests;
 
 use DateTimeImmutable;
 use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Encoding\JoseEncoder;
 use Lcobucci\JWT\Token\Plain;
 use PHPUnit\Framework\TestCase;
 
@@ -57,5 +58,43 @@ final class TimeFractionPrecisionTest extends TestCase
         yield ['1613938511.023691'];
         yield ['1613938511.018045'];
         yield ['1616074725.008455'];
+    }
+
+    /**
+     * @test
+     * @dataProvider timeFractionConversions
+     *
+     * @param float|int|string $issuedAt
+     */
+    public function typeConversionDoesNotCauseParsingErrors($issuedAt, string $timeFraction): void
+    {
+        $encoder = new JoseEncoder();
+        $headers = $encoder->base64UrlEncode($encoder->jsonEncode(['typ' => 'JWT', 'alg' => 'none']));
+        $claims  = $encoder->base64UrlEncode($encoder->jsonEncode(['iat' => $issuedAt]));
+
+        $config      = Configuration::forUnsecuredSigner();
+        $parsedToken = $config->parser()->parse($headers . '.' . $claims . '.');
+
+        self::assertInstanceOf(Plain::class, $parsedToken);
+        self::assertSame($timeFraction, $parsedToken->claims()->get('iat')->format('U.u'));
+    }
+
+    /** @return iterable<array{0: float|int|string, 1: string}> */
+    public function timeFractionConversions(): iterable
+    {
+        yield [1616481863.528781890869140625, '1616481863.528782'];
+        yield [1616497608.0510409, '1616497608.051041'];
+        yield [1616536852.1000001, '1616536852.100000'];
+        yield [1616457346.3878131, '1616457346.387813'];
+        yield [1616457346.0, '1616457346.000000'];
+
+        yield [1616457346, '1616457346.000000'];
+
+        yield ['1616481863.528781890869140625', '1616481863.528782'];
+        yield ['1616497608.0510409', '1616497608.051041'];
+        yield ['1616536852.1000001', '1616536852.100000'];
+        yield ['1616457346.3878131', '1616457346.387813'];
+        yield ['1616457346.0', '1616457346.000000'];
+        yield ['1616457346', '1616457346.000000'];
     }
 }


### PR DESCRIPTION
We received reports of users experiencing exceptions when parsing JWTs with timestamps with precision beyond microseconds on time-fractions.

This guards against having any kind of edge-case when dealing with floats as input to the creation of DateTimeImmutable objects.