### PR TITLE
[docs] Clarify change in date-formats

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -131,7 +131,7 @@ There are 4 main differences on the new API:
 
 1. Token configuration methods were renamed
 1. Signature is created via `Builder#getToken()` (instead of `Builder#sign()`)
-1. `DateTimeImmutable` objects are now for the registered claims with dates
+1. `DateTimeImmutable` objects are now used for the registered claims with dates, which are by default encoded as floats with microseconds as precision
 1. Headers should be replicated manually - whenever necessary
 
 Here's the migration:
@@ -176,6 +176,17 @@ Here's the migration:
 -    ->sign(new Sha256(), 'testing')
 -    ->getToken();
 +    ->getToken($config->signer(), $config->signingKey());
+```
+
+#### Date precision
+
+If you want to continue using Unix timestamps, you can use the `withUnixTimestampDates()`-formatter:
+
+```diff
+<?php
+
+-$builder = new Builder());
++$builder = $config->builder(ChainedFormatter::withUnixTimestampDates());
 ```
 
 #### Support for multiple audiences


### PR DESCRIPTION
I recently upgraded a project to `lcobucci/jwt:4.1`. My issue was that tokens generated by v4 were rejected by the v3 version of this library, because the `iat`-claim validation always failed.

I could solve this issue by using the method described in this PR.

I'm not sure what caused this issue, but I guess it was leeway-related.

Related to #710