### PR TITLE
Add `Parser::parseUnencrypted()`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,11 @@
     },
     "config": {
         "preferred-install": "dist",
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "infection/extension-installer": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "phpstan/extension-installer": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -55,11 +55,6 @@
     },
     "config": {
         "preferred-install": "dist",
-        "sort-packages": true,
-        "allow-plugins": {
-            "infection/extension-installer": true,
-            "dealerdirect/phpcodesniffer-composer-installer": true,
-            "phpstan/extension-installer": true
-        }
+        "sort-packages": true
     }
 }

--- a/src/JwtFacade.php
+++ b/src/JwtFacade.php
@@ -13,8 +13,6 @@ use Lcobucci\JWT\Validation\SignedWith;
 use Lcobucci\JWT\Validation\ValidAt;
 use Lcobucci\JWT\Validation\Validator;
 
-use function assert;
-
 final class JwtFacade
 {
     /** @param callable(Builder):Builder $customiseBuilder */
@@ -35,14 +33,12 @@ final class JwtFacade
     }
 
     public function parse(
-        string $jwt,
+        string $unencryptedJwt,
         SignedWith $signedWith,
         ValidAt $validAt,
         Constraint ...$constraints
     ): UnencryptedToken {
-        $token = (new Parser(new JoseEncoder()))->parse($jwt);
-
-        assert($token instanceof UnencryptedToken);
+        $token = (new Parser(new JoseEncoder()))->parseUnencrypted($unencryptedJwt);
 
         (new Validator())->assert(
             $token,

--- a/src/Token/InvalidTokenStructure.php
+++ b/src/Token/InvalidTokenStructure.php
@@ -22,4 +22,9 @@ final class InvalidTokenStructure extends InvalidArgumentException implements Ex
     {
         return new self('Value is not in the allowed date format: ' . $value);
     }
+
+    public static function unencryptedTokenExpected(string $unexpected): self
+    {
+        return new self('The JWT string was expected to decode to an unencrypted token, got: ' . $unexpected);
+    }
 }

--- a/src/Token/Parser.php
+++ b/src/Token/Parser.php
@@ -26,7 +26,7 @@ final class Parser implements ParserInterface
         $this->decoder = $decoder;
     }
 
-    public function parse(string $jwt): TokenInterface
+    public function parse(string $jwt): Plain
     {
         [$encodedHeaders, $encodedClaims, $encodedSignature] = $this->splitJwt($jwt);
 
@@ -42,7 +42,7 @@ final class Parser implements ParserInterface
     /**
      * Splits the JWT string into an array
      *
-     * @return string[]
+     * @return array{string, string, string}
      *
      * @throws InvalidTokenStructure When JWT doesn't have all parts.
      */
@@ -87,7 +87,7 @@ final class Parser implements ParserInterface
     /**
      * Parses the claim set from a string
      *
-     * @return mixed[]
+     * @return array<string, mixed>
      *
      * @throws InvalidTokenStructure When parsed content isn't an array or contains non-parseable dates.
      */
@@ -139,7 +139,7 @@ final class Parser implements ParserInterface
     /**
      * Returns the signature from given data
      *
-     * @param mixed[] $header
+     * @param array<string, mixed> $header
      */
     private function parseSignature(array $header, string $data): Signature
     {

--- a/test/unit/Token/ParserTest.php
+++ b/test/unit/Token/ParserTest.php
@@ -599,7 +599,9 @@ final class ParserTest extends TestCase
                 $data
             );
 
+        $parser = $this->createParser();
+
         $this->expectException(InvalidTokenStructure::class);
-        $this->createParser()->parse('a.b.');
+        $parser->parse('a.b.');
     }
 }


### PR DESCRIPTION
The following code currently works fine, but triggers a static analysis error due to the loose return type of `Parser::parse()`:

```php
$token = (new Parser(new JoseEncoder()))->parse($jwtString);
$token->claims();

// PHPStan says: Call to an undefined method Lcobucci\JWT\Token::claims().
```

I understand from previous discussion that `Parser::parse()` may also be used to handle encrypted tokens in the future.

Instead of handling other possible parse results in the application - and duplicating proper error handling - I think it is valuable for this library to offer a method that only deals with unencrypted tokens. This way, application code is simplified and proper error handling is ensured. Thus, I propose the following new method:

```php
$token = (new Parser(new JoseEncoder()))->parseUnencrypted($unencryptedJwtString);
assert($token instanceof UnencryptedToken);
```