### PR TITLE
Key: permit empty keys only with `::empty()` factory method

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,7 @@
 /*.yml                          export-ignore
 /CONTRIBUTING.md                export-ignore
 /*.dist                         export-ignore
+/phpstan-baseline.neon          export-ignore
 /phpbench.json                  export-ignore
 /composer.lock                  export-ignore
 /README.md                      export-ignore

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,12 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Parameter \\#1 \\$contents of class Lcobucci\\\\JWT\\\\Signer\\\\Key\\\\InMemory constructor expects non\\-empty\\-string, string given\\.$#"
+			count: 3
+			path: src/Signer/Key/InMemory.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between non\\-empty\\-string and '' will always evaluate to false\\.$#"
+			count: 1
+			path: src/Signer/Key/InMemory.php
+

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,3 +1,6 @@
+includes:
+    - phpstan-baseline.neon
+
 parameters:
     level: 8 # not yet ready for all the `mixed` checks
     paths:

--- a/src/Signer/InvalidKeyProvided.php
+++ b/src/Signer/InvalidKeyProvided.php
@@ -17,4 +17,9 @@ final class InvalidKeyProvided extends InvalidArgumentException implements Excep
     {
         return new self('This key is not compatible with this signer');
     }
+
+    public static function cannotBeEmpty(): self
+    {
+        return new self('Key cannot be empty');
+    }
 }

--- a/src/Signer/Key/InMemory.php
+++ b/src/Signer/Key/InMemory.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Lcobucci\JWT\Signer\Key;
 
+use Lcobucci\JWT\Signer\InvalidKeyProvided;
 use Lcobucci\JWT\Signer\Key;
 use Lcobucci\JWT\SodiumBase64Polyfill;
 use SplFileObject;
@@ -18,13 +19,21 @@ final class InMemory implements Key
 
     private function __construct(string $contents, string $passphrase)
     {
+        if ($contents === '') {
+            throw InvalidKeyProvided::cannotBeEmpty();
+        }
+
         $this->contents   = $contents;
         $this->passphrase = $passphrase;
     }
 
     public static function empty(): self
     {
-        return new self('', '');
+        $emptyKey             = new self('empty', 'empty');
+        $emptyKey->contents   = '';
+        $emptyKey->passphrase = '';
+
+        return $emptyKey;
     }
 
     public static function plainText(string $contents, string $passphrase = ''): self

--- a/src/Signer/Key/InMemory.php
+++ b/src/Signer/Key/InMemory.php
@@ -17,6 +17,7 @@ final class InMemory implements Key
     private string $contents;
     private string $passphrase;
 
+    /** @param non-empty-string $contents */
     private function __construct(string $contents, string $passphrase)
     {
         if ($contents === '') {

--- a/test/unit/ConfigurationTest.php
+++ b/test/unit/ConfigurationTest.php
@@ -110,7 +110,7 @@ final class ConfigurationTest extends TestCase
      */
     public function forUnsecuredSignerShouldConfigureSignerAndBothKeys(): void
     {
-        $key    = InMemory::plainText('');
+        $key    = InMemory::empty();
         $config = Configuration::forUnsecuredSigner();
 
         self::assertInstanceOf(None::class, $config->signer());

--- a/test/unit/Signer/Key/InMemoryTest.php
+++ b/test/unit/Signer/Key/InMemoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Lcobucci\JWT\Signer\Key;
 
 use Lcobucci\JWT\Encoding\CannotDecodeContent;
+use Lcobucci\JWT\Signer\InvalidKeyProvided;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
 
@@ -135,12 +136,28 @@ final class InMemoryTest extends TestCase
      *
      * @covers ::__construct
      * @covers ::plainText
-     * @covers ::passphrase
+     * @covers \Lcobucci\JWT\Signer\InvalidKeyProvided::cannotBeEmpty
      */
-    public function passphraseShouldReturnAnEmptyStringWhenNothingWasConfigured(): void
+    public function emptyPlainTextContentShouldRaiseException(): void
     {
-        $key = InMemory::plainText('testing');
+        $this->expectException(InvalidKeyProvided::class);
 
-        self::assertSame('', $key->passphrase());
+        InMemory::plainText('');
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::__construct
+     * @covers ::base64Encoded
+     * @covers \Lcobucci\JWT\Signer\InvalidKeyProvided::cannotBeEmpty
+     *
+     * @uses \Lcobucci\JWT\SodiumBase64Polyfill::base642bin
+     */
+    public function emptyBase64ContentShouldRaiseException(): void
+    {
+        $this->expectException(InvalidKeyProvided::class);
+
+        InMemory::base64Encoded('');
     }
 }


### PR DESCRIPTION
I consider this a security bug that should be addressed with urgent.

Before this PR, misconfigurations can easily lead to unsecured token issuance under the radar, expecially where creator = consumer.