### PR TITLE
Use abstraction instead of concretion

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -9,7 +9,6 @@ use Lcobucci\JWT\Signer\CannotSignPayload;
 use Lcobucci\JWT\Signer\Ecdsa\ConversionFailed;
 use Lcobucci\JWT\Signer\InvalidKeyProvided;
 use Lcobucci\JWT\Signer\Key;
-use Lcobucci\JWT\Token\Plain;
 use Lcobucci\JWT\Token\RegisteredClaimGiven;
 
 interface Builder
@@ -69,5 +68,5 @@ interface Builder
      * @throws InvalidKeyProvided  When issue key is invalid/incompatible.
      * @throws ConversionFailed    When signature could not be converted.
      */
-    public function getToken(Signer $signer, Key $key): Plain;
+    public function getToken(Signer $signer, Key $key): UnencryptedToken;
 }

--- a/src/Token/Builder.php
+++ b/src/Token/Builder.php
@@ -10,6 +10,7 @@ use Lcobucci\JWT\Encoder;
 use Lcobucci\JWT\Encoding\CannotEncodeContent;
 use Lcobucci\JWT\Signer;
 use Lcobucci\JWT\Signer\Key;
+use Lcobucci\JWT\UnencryptedToken;
 
 use function array_diff;
 use function array_merge;
@@ -100,7 +101,7 @@ final class Builder implements BuilderInterface
         );
     }
 
-    public function getToken(Signer $signer, Key $key): Plain
+    public function getToken(Signer $signer, Key $key): UnencryptedToken
     {
         $headers        = $this->headers;
         $headers['alg'] = $signer->algorithmId();


### PR DESCRIPTION
We introduced the `UnencryptedToken` interface after v4.0.0 was released. So, we couldn't update the `Builder` to use... now we can.