### PR TITLE
Make method explicitly internal

### DIFF
--- a/src/Signer/Ecdsa.php
+++ b/src/Signer/Ecdsa.php
@@ -56,6 +56,7 @@ abstract class Ecdsa extends OpenSSL
         }
     }
 
+    /** @internal */
     abstract public function expectedKeyLength(): int;
 
     /**


### PR DESCRIPTION
This was missed prior to releasing v4.2.0.