### PR TITLE
Make test assertion more strict

### DIFF
--- a/test/functional/ES512TokenTest.php
+++ b/test/functional/ES512TokenTest.php
@@ -101,11 +101,11 @@ class ES512TokenTest extends TestCase
             ->withHeader('jki', '1234')
             ->getToken($this->config->signer(), $this->config->signingKey());
 
-        self::assertEquals('1234', $token->headers()->get('jki'));
-        self::assertEquals('http://api.abc.com', $token->claims()->get(Token\RegisteredClaims::ISSUER));
-        self::assertEquals($user, $token->claims()->get('user'));
+        self::assertSame('1234', $token->headers()->get('jki'));
+        self::assertSame('http://api.abc.com', $token->claims()->get(Token\RegisteredClaims::ISSUER));
+        self::assertSame($user, $token->claims()->get('user'));
 
-        self::assertEquals(
+        self::assertSame(
             ['http://client.abc.com', 'http://client2.abc.com'],
             $token->claims()->get(Token\RegisteredClaims::AUDIENCE),
         );
@@ -123,7 +123,7 @@ class ES512TokenTest extends TestCase
         assert($read instanceof Token\Plain);
 
         self::assertEquals($generated, $read);
-        self::assertEquals('testing', $read->claims()->get('user')['name']);
+        self::assertSame('testing', $read->claims()->get('user')['name']);
     }
 
     /**

--- a/test/functional/EcdsaTokenTest.php
+++ b/test/functional/EcdsaTokenTest.php
@@ -103,11 +103,11 @@ class EcdsaTokenTest extends TestCase
                          ->withHeader('jki', '1234')
                          ->getToken($this->config->signer(), $this->config->signingKey());
 
-        self::assertEquals('1234', $token->headers()->get('jki'));
-        self::assertEquals('http://api.abc.com', $token->claims()->get(Token\RegisteredClaims::ISSUER));
-        self::assertEquals($user, $token->claims()->get('user'));
+        self::assertSame('1234', $token->headers()->get('jki'));
+        self::assertSame('http://api.abc.com', $token->claims()->get(Token\RegisteredClaims::ISSUER));
+        self::assertSame($user, $token->claims()->get('user'));
 
-        self::assertEquals(
+        self::assertSame(
             ['http://client.abc.com', 'http://client2.abc.com'],
             $token->claims()->get(Token\RegisteredClaims::AUDIENCE),
         );
@@ -125,7 +125,7 @@ class EcdsaTokenTest extends TestCase
         assert($read instanceof Token\Plain);
 
         self::assertEquals($generated, $read);
-        self::assertEquals('testing', $read->claims()->get('user')['name']);
+        self::assertSame('testing', $read->claims()->get('user')['name']);
     }
 
     /**
@@ -234,6 +234,6 @@ class EcdsaTokenTest extends TestCase
         $constraint = new SignedWith(Sha512::create(), InMemory::plainText($key));
 
         self::assertTrue($this->config->validator()->validate($token, $constraint));
-        self::assertEquals('world', $token->claims()->get('hello'));
+        self::assertSame('world', $token->claims()->get('hello'));
     }
 }

--- a/test/functional/EddsaTokenTest.php
+++ b/test/functional/EddsaTokenTest.php
@@ -84,11 +84,11 @@ class EddsaTokenTest extends TestCase
                          ->withHeader('jki', '1234')
                          ->getToken($this->config->signer(), $this->config->signingKey());
 
-        self::assertEquals('1234', $token->headers()->get('jki'));
-        self::assertEquals('http://api.abc.com', $token->claims()->get(Token\RegisteredClaims::ISSUER));
-        self::assertEquals($user, $token->claims()->get('user'));
+        self::assertSame('1234', $token->headers()->get('jki'));
+        self::assertSame('http://api.abc.com', $token->claims()->get(Token\RegisteredClaims::ISSUER));
+        self::assertSame($user, $token->claims()->get('user'));
 
-        self::assertEquals(
+        self::assertSame(
             ['http://client.abc.com', 'http://client2.abc.com'],
             $token->claims()->get(Token\RegisteredClaims::AUDIENCE),
         );
@@ -106,7 +106,7 @@ class EddsaTokenTest extends TestCase
         assert($read instanceof Token\Plain);
 
         self::assertEquals($generated, $read);
-        self::assertEquals('testing', $read->claims()->get('user')['name']);
+        self::assertSame('testing', $read->claims()->get('user')['name']);
     }
 
     /**

--- a/test/functional/HmacTokenTest.php
+++ b/test/functional/HmacTokenTest.php
@@ -67,10 +67,10 @@ class HmacTokenTest extends TestCase
                          ->withHeader('jki', '1234')
                          ->getToken($this->config->signer(), $this->config->signingKey());
 
-        self::assertEquals('1234', $token->headers()->get('jki'));
-        self::assertEquals(['http://client.abc.com'], $token->claims()->get(Token\RegisteredClaims::AUDIENCE));
-        self::assertEquals('http://api.abc.com', $token->claims()->get(Token\RegisteredClaims::ISSUER));
-        self::assertEquals($user, $token->claims()->get('user'));
+        self::assertSame('1234', $token->headers()->get('jki'));
+        self::assertSame(['http://client.abc.com'], $token->claims()->get(Token\RegisteredClaims::AUDIENCE));
+        self::assertSame('http://api.abc.com', $token->claims()->get(Token\RegisteredClaims::ISSUER));
+        self::assertSame($user, $token->claims()->get('user'));
 
         return $token;
     }
@@ -85,7 +85,7 @@ class HmacTokenTest extends TestCase
         assert($read instanceof Token\Plain);
 
         self::assertEquals($generated, $read);
-        self::assertEquals('testing', $read->claims()->get('user')['name']);
+        self::assertSame('testing', $read->claims()->get('user')['name']);
     }
 
     /**
@@ -148,7 +148,7 @@ class HmacTokenTest extends TestCase
         $constraint = new SignedWith($config->signer(), $config->verificationKey());
 
         self::assertTrue($config->validator()->validate($token, $constraint));
-        self::assertEquals('world', $token->claims()->get('hello'));
+        self::assertSame('world', $token->claims()->get('hello'));
     }
 
     /** @test */

--- a/test/functional/MaliciousTamperingPreventionTest.php
+++ b/test/functional/MaliciousTamperingPreventionTest.php
@@ -85,7 +85,7 @@ final class MaliciousTamperingPreventionTest extends TestCase
         $token = $this->config->parser()->parse($bad);
         assert($token instanceof Plain);
 
-        self::assertEquals('world', $token->claims()->get('hello'), 'The claim content should not be modified');
+        self::assertSame('world', $token->claims()->get('hello'), 'The claim content should not be modified');
 
         $validator = $this->config->validator();
 

--- a/test/functional/RsaTokenTest.php
+++ b/test/functional/RsaTokenTest.php
@@ -99,10 +99,10 @@ class RsaTokenTest extends TestCase
                          ->withHeader('jki', '1234')
                          ->getToken($this->config->signer(), $this->config->signingKey());
 
-        self::assertEquals('1234', $token->headers()->get('jki'));
-        self::assertEquals(['http://client.abc.com'], $token->claims()->get(Token\RegisteredClaims::AUDIENCE));
-        self::assertEquals('http://api.abc.com', $token->claims()->get(Token\RegisteredClaims::ISSUER));
-        self::assertEquals($user, $token->claims()->get('user'));
+        self::assertSame('1234', $token->headers()->get('jki'));
+        self::assertSame(['http://client.abc.com'], $token->claims()->get(Token\RegisteredClaims::AUDIENCE));
+        self::assertSame('http://api.abc.com', $token->claims()->get(Token\RegisteredClaims::ISSUER));
+        self::assertSame($user, $token->claims()->get('user'));
 
         return $token;
     }
@@ -117,7 +117,7 @@ class RsaTokenTest extends TestCase
         assert($read instanceof Token\Plain);
 
         self::assertEquals($generated, $read);
-        self::assertEquals('testing', $read->claims()->get('user')['name']);
+        self::assertSame('testing', $read->claims()->get('user')['name']);
     }
 
     /**
@@ -194,6 +194,6 @@ class RsaTokenTest extends TestCase
         $constraint = new SignedWith($this->config->signer(), $this->config->verificationKey());
 
         self::assertTrue($this->config->validator()->validate($token, $constraint));
-        self::assertEquals('world', $token->claims()->get('hello'));
+        self::assertSame('world', $token->claims()->get('hello'));
     }
 }

--- a/test/functional/UnsignedTokenTest.php
+++ b/test/functional/UnsignedTokenTest.php
@@ -69,8 +69,8 @@ class UnsignedTokenTest extends TestCase
 
         self::assertEquals(new Token\Signature('', ''), $token->signature());
         self::assertEquals(['http://client.abc.com'], $token->claims()->get(Token\RegisteredClaims::AUDIENCE));
-        self::assertEquals('http://api.abc.com', $token->claims()->get(Token\RegisteredClaims::ISSUER));
-        self::assertSame($expiration, $token->claims()->get(Token\RegisteredClaims::EXPIRATION_TIME));
+        self::assertSame('http://api.abc.com', $token->claims()->get(Token\RegisteredClaims::ISSUER));
+        self::assertEquals($expiration, $token->claims()->get(Token\RegisteredClaims::EXPIRATION_TIME));
         self::assertEquals($user, $token->claims()->get('user'));
 
         return $token;
@@ -86,7 +86,7 @@ class UnsignedTokenTest extends TestCase
         assert($read instanceof Token\Plain);
 
         self::assertEquals($generated, $read);
-        self::assertEquals('testing', $read->claims()->get('user')['name']);
+        self::assertSame('testing', $read->claims()->get('user')['name']);
     }
 
     /**

--- a/test/unit/Signer/Blake2bTest.php
+++ b/test/unit/Signer/Blake2bTest.php
@@ -48,7 +48,7 @@ final class Blake2bTest extends TestCase
     {
         $signer = new Blake2b();
 
-        self::assertEquals('BLAKE2B', $signer->algorithmId());
+        self::assertSame('BLAKE2B', $signer->algorithmId());
     }
 
     /**

--- a/test/unit/Signer/EddsaTest.php
+++ b/test/unit/Signer/EddsaTest.php
@@ -23,7 +23,7 @@ final class EddsaTest extends TestCase
      */
     public function algorithmIdMustBeCorrect(): void
     {
-        self::assertEquals('EdDSA', $this->getSigner()->algorithmId());
+        self::assertSame('EdDSA', $this->getSigner()->algorithmId());
     }
 
     /**

--- a/test/unit/Signer/Hmac/Sha256Test.php
+++ b/test/unit/Signer/Hmac/Sha256Test.php
@@ -17,7 +17,7 @@ final class Sha256Test extends TestCase
     {
         $signer = new Sha256();
 
-        self::assertEquals('HS256', $signer->algorithmId());
+        self::assertSame('HS256', $signer->algorithmId());
     }
 
     /**
@@ -29,7 +29,7 @@ final class Sha256Test extends TestCase
     {
         $signer = new Sha256();
 
-        self::assertEquals('sha256', $signer->algorithm());
+        self::assertSame('sha256', $signer->algorithm());
     }
 
     /**

--- a/test/unit/Signer/Hmac/Sha384Test.php
+++ b/test/unit/Signer/Hmac/Sha384Test.php
@@ -17,7 +17,7 @@ final class Sha384Test extends TestCase
     {
         $signer = new Sha384();
 
-        self::assertEquals('HS384', $signer->algorithmId());
+        self::assertSame('HS384', $signer->algorithmId());
     }
 
     /**
@@ -29,7 +29,7 @@ final class Sha384Test extends TestCase
     {
         $signer = new Sha384();
 
-        self::assertEquals('sha384', $signer->algorithm());
+        self::assertSame('sha384', $signer->algorithm());
     }
 
     /**

--- a/test/unit/Signer/Hmac/Sha512Test.php
+++ b/test/unit/Signer/Hmac/Sha512Test.php
@@ -17,7 +17,7 @@ final class Sha512Test extends TestCase
     {
         $signer = new Sha512();
 
-        self::assertEquals('HS512', $signer->algorithmId());
+        self::assertSame('HS512', $signer->algorithmId());
     }
 
     /**
@@ -29,7 +29,7 @@ final class Sha512Test extends TestCase
     {
         $signer = new Sha512();
 
-        self::assertEquals('sha512', $signer->algorithm());
+        self::assertSame('sha512', $signer->algorithm());
     }
 
     /**

--- a/test/unit/Signer/HmacTest.php
+++ b/test/unit/Signer/HmacTest.php
@@ -44,7 +44,7 @@ final class HmacTest extends TestCase
     {
         $hash = hash_hmac('sha256', 'test', '123', true);
 
-        self::assertEquals($hash, $this->signer->sign('test', InMemory::plainText('123')));
+        self::assertSame($hash, $this->signer->sign('test', InMemory::plainText('123')));
 
         return $hash;
     }

--- a/test/unit/Signer/NoneTest.php
+++ b/test/unit/Signer/NoneTest.php
@@ -18,7 +18,7 @@ final class NoneTest extends TestCase
     {
         $signer = new None();
 
-        self::assertEquals('none', $signer->algorithmId());
+        self::assertSame('none', $signer->algorithmId());
     }
 
     /**
@@ -32,7 +32,7 @@ final class NoneTest extends TestCase
     {
         $signer = new None();
 
-        self::assertEquals('', $signer->sign('test', InMemory::plainText('test')));
+        self::assertSame('', $signer->sign('test', InMemory::plainText('test')));
     }
 
     /**

--- a/test/unit/Signer/Rsa/Sha256Test.php
+++ b/test/unit/Signer/Rsa/Sha256Test.php
@@ -19,7 +19,7 @@ final class Sha256Test extends TestCase
     {
         $signer = new Sha256();
 
-        self::assertEquals('RS256', $signer->algorithmId());
+        self::assertSame('RS256', $signer->algorithmId());
     }
 
     /**
@@ -31,6 +31,6 @@ final class Sha256Test extends TestCase
     {
         $signer = new Sha256();
 
-        self::assertEquals(OPENSSL_ALGO_SHA256, $signer->algorithm());
+        self::assertSame(OPENSSL_ALGO_SHA256, $signer->algorithm());
     }
 }

--- a/test/unit/Signer/Rsa/Sha384Test.php
+++ b/test/unit/Signer/Rsa/Sha384Test.php
@@ -19,7 +19,7 @@ final class Sha384Test extends TestCase
     {
         $signer = new Sha384();
 
-        self::assertEquals('RS384', $signer->algorithmId());
+        self::assertSame('RS384', $signer->algorithmId());
     }
 
     /**
@@ -31,6 +31,6 @@ final class Sha384Test extends TestCase
     {
         $signer = new Sha384();
 
-        self::assertEquals(OPENSSL_ALGO_SHA384, $signer->algorithm());
+        self::assertSame(OPENSSL_ALGO_SHA384, $signer->algorithm());
     }
 }

--- a/test/unit/Signer/Rsa/Sha512Test.php
+++ b/test/unit/Signer/Rsa/Sha512Test.php
@@ -19,7 +19,7 @@ final class Sha512Test extends TestCase
     {
         $signer = new Sha512();
 
-        self::assertEquals('RS512', $signer->algorithmId());
+        self::assertSame('RS512', $signer->algorithmId());
     }
 
     /**
@@ -31,6 +31,6 @@ final class Sha512Test extends TestCase
     {
         $signer = new Sha512();
 
-        self::assertEquals(OPENSSL_ALGO_SHA512, $signer->algorithm());
+        self::assertSame(OPENSSL_ALGO_SHA512, $signer->algorithm());
     }
 }


### PR DESCRIPTION
# Changed log

- It should use the `assertSame` to make assert equals strict.