### PR TITLE
Deprecate empty Signer, empty Key and empty Signature

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -105,26 +105,6 @@ $configuration = Configuration::forAsymmetricSigner(
 );
 ```
 
-### For no algorithm
-
-!!! Warning
-    This configuration type is **NOT** recommended for production environments.
-    It's only provided to allow people to have a simpler and faster setup for tests, avoiding any kind of signature creation/verification.
-
-```php
-<?php
-declare(strict_types=1);
-
-use Lcobucci\JWT\Configuration;
-
-require 'vendor/autoload.php';
-
-$configuration = Configuration::forUnsecuredSigner(
-    // You may also override the JOSE encoder/decoder if needed by providing
-    // extra arguments here
-);
-```
-
 ## Customisation
 
 By using the setters of the `Lcobucci\JWT\Configuration` you may customise the setup of this library.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -25,13 +25,13 @@ If you are using any variant of ECDSA, please change your code following this ex
 ```diff
  <?php
  declare(strict_types=1);
- 
+
  use Lcobucci\JWT\Configuration;
  use Lcobucci\JWT\Signer;
  use Lcobucci\JWT\Signer\Key\InMemory;
- 
+
  require 'vendor/autoload.php';
- 
+
  $configuration = Configuration::forAsymmetricSigner(
 -    Signer\Ecdsa\Sha256::create(),
 +    new Signer\Ecdsa\Sha256(),
@@ -40,6 +40,36 @@ If you are using any variant of ECDSA, please change your code following this ex
      // You may also override the JOSE encoder/decoder if needed
      // by providing extra arguments here
  );
+```
+
+### Removal of `none` algorithm
+
+To promote a more secure usage of the library and prevent misuse we decided to deviate from the RFC and drop `none`, which means that the following components are being removed:
+
+* `Lcobucci\JWT\Configuration::forUnsecuredSigner()`
+* `Lcobucci\JWT\Signer\Key\InMemory::empty()`
+* `Lcobucci\JWT\Signer\None`
+* `Lcobucci\JWT\Token\Signature::fromEmptyData()`
+
+If you're relying on it and still want to have that on your system, please create your own implementation.
+
+If you're using it because it's "fast", please look into adoption the non-standard Blake2b implementation:
+
+```diff
+ <?php
+ declare(strict_types=1);
+
+ use Lcobucci\JWT\Configuration;
+ use Lcobucci\JWT\Signer;
+ use Lcobucci\JWT\Signer\Key\InMemory;
+
+ require 'vendor/autoload.php';
+
+-$configuration = Configuration::forUnsecuredSigner();
++$configuration = Configuration::forSymmetricSigner(
++    new Signer\Blake2b(),
++    InMemory::base64Encoded('MpQd6dDPiqnzFSWmpUfLy4+Rdls90Ca4C8e0QD0IxqY=')
++);
 ```
 
 ## v3.x to v4.x

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -11,3 +11,19 @@ parameters:
             #^.+ deprecated class Lcobucci\\\\JWT\\\\Signer\\\\.+:
             Deprecated since v4\\.2$#
         """
+        - """
+            #^Call to deprecated method fromEmptyData\\(\\) of class Lcobucci\\\\JWT\\\\Token\\\\Signature:
+            Deprecated since v4\\.3$#
+        """
+        - """
+            #^Call to deprecated method forUnsecuredSigner\\(\\) of class Lcobucci\\\\JWT\\\\Configuration:
+            Deprecated since v4\\.3$#
+        """
+        - """
+            #^Call to deprecated method empty\\(\\) of class Lcobucci\\\\JWT\\\\Signer\\\\Key\\\\InMemory:
+            Deprecated since v4\\.3$#
+        """
+        - """
+            #^.+ of deprecated class Lcobucci\\\\JWT\\\\Signer\\\\None:
+            Deprecated since v4\\.3$#
+        """

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -80,6 +80,7 @@ final class Configuration
         );
     }
 
+    /** @deprecated Deprecated since v4.3 */
     public static function forUnsecuredSigner(
         ?Encoder $encoder = null,
         ?Decoder $decoder = null

--- a/src/Signer/Key/InMemory.php
+++ b/src/Signer/Key/InMemory.php
@@ -29,6 +29,7 @@ final class InMemory implements Key
         $this->passphrase = $passphrase;
     }
 
+    /** @deprecated Deprecated since v4.3 */
     public static function empty(): self
     {
         $emptyKey             = new self('empty', 'empty');

--- a/src/Signer/None.php
+++ b/src/Signer/None.php
@@ -5,6 +5,7 @@ namespace Lcobucci\JWT\Signer;
 
 use Lcobucci\JWT\Signer;
 
+/** @deprecated Deprecated since v4.3 */
 final class None implements Signer
 {
     public function algorithmId(): string

--- a/src/Token/Signature.php
+++ b/src/Token/Signature.php
@@ -14,6 +14,7 @@ final class Signature
         $this->encoded = $encoded;
     }
 
+    /** @deprecated Deprecated since v4.3 */
     public static function fromEmptyData(): self
     {
         return new self('', '');


### PR DESCRIPTION
Addresses https://github.com/lcobucci/jwt/issues/937 for `v4`.

This PR deprecates:

1. `\Lcobucci\JWT\Signer\None`
2. `\Lcobucci\JWT\Signer\Key\InMemory::empty`
3. `\Lcobucci\JWT\Token\Signature::fromEmptyData`
4. and as a result, `\Lcobucci\JWT\Configuration::forUnsecuredSigner`

The likelyhood of them being misused are too high.

If someone needs them, they can implement it by themself.