### PR TITLE
Use roave/backward-compatibility-check directly

### DIFF
--- a/.github/workflows/backwards-compatibility.yml
+++ b/.github/workflows/backwards-compatibility.yml
@@ -15,7 +15,35 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: "BC Check"
-        uses: docker://nyholm/roave-bc-check-ga
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@2.24.0"
         with:
-          args: --from=${{ github.event.pull_request.base.sha }}
+          php-version: "8.1"
+          ini-values: memory_limit=-1
+          tools: composer:v2, cs2pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer global config cache-files-dir)"
+
+      - name: "Cache dependencies"
+        uses: "actions/cache@v3.2.4"
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: "php-8.1-bc-break-check-${{ hashFiles('.github/workflows/backwards-compatibility.yml') }}"
+          restore-keys: "php-8.1-bc-break-check-"
+
+      # Only necessary until https://github.com/Roave/BackwardCompatibilityCheck/pull/737 gets resolved
+      - name: "Configure custom repository"
+        run: |
+          echo '{"repositories": [{"type":"vcs","url":"git@github.com:lcobucci/BackwardCompatibilityCheck.git"}]}' > ~/.composer/composer.json
+
+      - name: "Install dependencies"
+        # run: composer global require roave/backward-compatibility-check
+        run: composer global require "roave/backward-compatibility-check:dev-support-baseline-configuration"
+
+      - name: "BC Check"
+        run: |
+          ~/.composer/vendor/bin/roave-backward-compatibility-check --from=${{ github.event.pull_request.base.sha }} --format=github-actions

--- a/.roave-backward-compatibility-check.json
+++ b/.roave-backward-compatibility-check.json
@@ -1,0 +1,5 @@
+{
+  "baseline": [
+    "#\\[BC\\] SKIPPED: Unable to compile initializer in method Lcobucci\\\\.+#"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -32,5 +32,5 @@ free to check out Auth0's PHP SDK and free plan at
 [Total Downloads]: https://img.shields.io/packagist/dt/lcobucci/jwt.svg?style=flat-square
 [Latest Stable Version]: https://img.shields.io/packagist/v/lcobucci/jwt.svg?style=flat-square
 [Unstable Version]: https://img.shields.io/packagist/vpre/lcobucci/jwt.svg?style=flat-square
-[Build Status]: https://img.shields.io/github/workflow/status/lcobucci/jwt/PHPUnit%20tests/4.1.x?style=flat-square
+[Build Status]: https://img.shields.io/github/actions/workflow/status/lcobucci/jwt/phpunit.yml?branch=5.0.x&style=flat-square
 [Code Coverage]: https://codecov.io/gh/lcobucci/jwt/branch/4.1.x/graph/badge.svg

--- a/roave-bc-check.yaml
+++ b/roave-bc-check.yaml
@@ -1,3 +1,0 @@
-parameters:
-  ignoreErrors:
-    - '#\[BC\] SKIPPED: Unable to compile initializer in method Lcobucci\\.+#'


### PR DESCRIPTION
This removes the docker layer which is always failing due to new git configuration, simplifying the setup a lot.

We temporarily point to a fork so that we can still have a working baseline.