### PR TITLE
Support other PSR-20 implementations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "ext-json": "*",
         "ext-openssl": "*",
         "ext-sodium": "*",
-        "lcobucci/clock": "^3.0.0"
+        "lcobucci/clock": "^3.0.0",
+        "psr/clock": "^1.0"
     },
     "require-dev": {
         "infection/infection": "^0.26.19",

--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,11 @@
         "ext-json": "*",
         "ext-openssl": "*",
         "ext-sodium": "*",
-        "lcobucci/clock": "^3.0.0",
         "psr/clock": "^1.0"
     },
     "require-dev": {
         "infection/infection": "^0.26.19",
+        "lcobucci/clock": "^3.0",
         "lcobucci/coding-standard": "^9.0",
         "phpbench/phpbench": "^1.2.8",
         "phpstan/extension-installer": "^1.2",
@@ -35,6 +35,9 @@
         "phpstan/phpstan-phpunit": "^1.3.8",
         "phpstan/phpstan-strict-rules": "^1.5.0",
         "phpunit/phpunit": "^10.0.12"
+    },
+    "suggest": {
+        "lcobucci/clock": ">= 3.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,72 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6213231e73ab90ed5ac862e518dbee2b",
+    "content-hash": "c0d16b3be9c2f7b5b9d81fb835ad6d0f",
     "packages": [
-        {
-            "name": "lcobucci/clock",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/lcobucci/clock.git",
-                "reference": "039ef98c6b57b101d10bd11d8fdfda12cbd996dc"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/lcobucci/clock/zipball/039ef98c6b57b101d10bd11d8fdfda12cbd996dc",
-                "reference": "039ef98c6b57b101d10bd11d8fdfda12cbd996dc",
-                "shasum": ""
-            },
-            "require": {
-                "php": "~8.1.0 || ~8.2.0",
-                "psr/clock": "^1.0"
-            },
-            "provide": {
-                "psr/clock-implementation": "1.0"
-            },
-            "require-dev": {
-                "infection/infection": "^0.26",
-                "lcobucci/coding-standard": "^9.0",
-                "phpstan/extension-installer": "^1.2",
-                "phpstan/phpstan": "^1.9.4",
-                "phpstan/phpstan-deprecation-rules": "^1.1.1",
-                "phpstan/phpstan-phpunit": "^1.3.2",
-                "phpstan/phpstan-strict-rules": "^1.4.4",
-                "phpunit/phpunit": "^9.5.27"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Lcobucci\\Clock\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Luís Cobucci",
-                    "email": "lcobucci@gmail.com"
-                }
-            ],
-            "description": "Yet another clock abstraction",
-            "support": {
-                "issues": "https://github.com/lcobucci/clock/issues",
-                "source": "https://github.com/lcobucci/clock/tree/3.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/lcobucci",
-                    "type": "github"
-                },
-                {
-                    "url": "https://www.patreon.com/lcobucci",
-                    "type": "patreon"
-                }
-            ],
-            "time": "2022-12-19T15:00:24+00:00"
-        },
         {
             "name": "psr/clock",
             "version": "1.0.0",
@@ -1066,6 +1002,70 @@
                 "source": "https://github.com/justinrainbow/json-schema/tree/5.2.12"
             },
             "time": "2022-04-13T08:02:27+00:00"
+        },
+        {
+            "name": "lcobucci/clock",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lcobucci/clock.git",
+                "reference": "039ef98c6b57b101d10bd11d8fdfda12cbd996dc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lcobucci/clock/zipball/039ef98c6b57b101d10bd11d8fdfda12cbd996dc",
+                "reference": "039ef98c6b57b101d10bd11d8fdfda12cbd996dc",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.1.0 || ~8.2.0",
+                "psr/clock": "^1.0"
+            },
+            "provide": {
+                "psr/clock-implementation": "1.0"
+            },
+            "require-dev": {
+                "infection/infection": "^0.26",
+                "lcobucci/coding-standard": "^9.0",
+                "phpstan/extension-installer": "^1.2",
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-deprecation-rules": "^1.1.1",
+                "phpstan/phpstan-phpunit": "^1.3.2",
+                "phpstan/phpstan-strict-rules": "^1.4.4",
+                "phpunit/phpunit": "^9.5.27"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Lcobucci\\Clock\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Luís Cobucci",
+                    "email": "lcobucci@gmail.com"
+                }
+            ],
+            "description": "Yet another clock abstraction",
+            "support": {
+                "issues": "https://github.com/lcobucci/clock/issues",
+                "source": "https://github.com/lcobucci/clock/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/lcobucci",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/lcobucci",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2022-12-19T15:00:24+00:00"
         },
         {
             "name": "lcobucci/coding-standard",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0845c883bfa853ed0065aa7af416eac1",
+    "content-hash": "6213231e73ab90ed5ac862e518dbee2b",
     "packages": [
         {
             "name": "lcobucci/clock",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -200,7 +200,8 @@ It configures which are the base constraints to be used during validation.
 <?php
 declare(strict_types=1);
 
-use Lcobucci\Clock\SystemClock;
+use Lcobucci\Clock\SystemClock; // If you prefer, other PSR-20 implementations may also be used
+                                // (https://packagist.org/providers/psr/clock-implementation)
 use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Signer;
 use Lcobucci\JWT\Signer\Key\InMemory;

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -64,7 +64,8 @@ namespace MyApp;
 require 'vendor/autoload.php';
 
 use DateTimeImmutable;
-use Lcobucci\Clock\FrozenClock;
+use Lcobucci\Clock\FrozenClock; // If you prefer, other PSR-20 implementations may also be used
+                                // (https://packagist.org/providers/psr/clock-implementation)
 use Lcobucci\JWT\Builder;
 use Lcobucci\JWT\JwtFacade;
 use Lcobucci\JWT\Signer\Hmac\Sha256;
@@ -104,7 +105,8 @@ namespace MyApp;
 require 'vendor/autoload.php';
 
 use DateTimeImmutable;
-use Lcobucci\Clock\FrozenClock;
+use Lcobucci\Clock\FrozenClock; // If you prefer, other PSR-20 implementations may also be used
+                                // (https://packagist.org/providers/psr/clock-implementation)
 use Lcobucci\JWT\JwtFacade;
 use Lcobucci\JWT\Signer\Hmac\Sha256;
 use Lcobucci\JWT\Signer\Key\InMemory;

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -121,6 +121,16 @@ Or:
  );
 ```
 
+### `lcobucci/clock` is not installed by default anymore
+
+Thanks to [PSR-20](https://www.php-fig.org/psr/psr-20/), users can more easily plug-in other [clock implementations](https://packagist.org/providers/psr/clock-implementation) if they choose to do so.
+
+If you like and were already using `lcobucci/clock` on your system, you're required to explicitly add it as a production dependency:
+
+```sh
+composer require lcobucci/clock
+```
+
 ## v3.x to v4.x
 
 The `v4.0.0` aggregates about 5 years of work and contains **several BC-breaks**.

--- a/src/JwtFacade.php
+++ b/src/JwtFacade.php
@@ -5,7 +5,6 @@ namespace Lcobucci\JWT;
 
 use Closure;
 use DateTimeImmutable;
-use Lcobucci\Clock\Clock;
 use Lcobucci\Clock\SystemClock;
 use Lcobucci\JWT\Encoding\ChainedFormatter;
 use Lcobucci\JWT\Encoding\JoseEncoder;
@@ -14,6 +13,7 @@ use Lcobucci\JWT\Validation\Constraint;
 use Lcobucci\JWT\Validation\SignedWith;
 use Lcobucci\JWT\Validation\ValidAt;
 use Lcobucci\JWT\Validation\Validator;
+use Psr\Clock\ClockInterface as Clock;
 
 use function assert;
 

--- a/src/JwtFacade.php
+++ b/src/JwtFacade.php
@@ -5,7 +5,6 @@ namespace Lcobucci\JWT;
 
 use Closure;
 use DateTimeImmutable;
-use Lcobucci\Clock\SystemClock;
 use Lcobucci\JWT\Encoding\ChainedFormatter;
 use Lcobucci\JWT\Encoding\JoseEncoder;
 use Lcobucci\JWT\Signer\Key;
@@ -25,7 +24,12 @@ final class JwtFacade
         private readonly Parser $parser = new Token\Parser(new JoseEncoder()),
         ?Clock $clock = null,
     ) {
-        $this->clock = $clock ?? SystemClock::fromSystemTimezone();
+        $this->clock = $clock ?? new class implements Clock {
+            public function now(): DateTimeImmutable
+            {
+                return new DateTimeImmutable();
+            }
+        };
     }
 
     /** @param Closure(Builder, DateTimeImmutable):Builder $customiseBuilder */

--- a/src/Validation/Constraint/LooseValidAt.php
+++ b/src/Validation/Constraint/LooseValidAt.php
@@ -5,10 +5,10 @@ namespace Lcobucci\JWT\Validation\Constraint;
 
 use DateInterval;
 use DateTimeInterface;
-use Lcobucci\Clock\Clock;
 use Lcobucci\JWT\Token;
 use Lcobucci\JWT\Validation\ConstraintViolation;
 use Lcobucci\JWT\Validation\ValidAt as ValidAtInterface;
+use Psr\Clock\ClockInterface as Clock;
 
 final class LooseValidAt implements ValidAtInterface
 {

--- a/src/Validation/Constraint/StrictValidAt.php
+++ b/src/Validation/Constraint/StrictValidAt.php
@@ -5,11 +5,11 @@ namespace Lcobucci\JWT\Validation\Constraint;
 
 use DateInterval;
 use DateTimeInterface;
-use Lcobucci\Clock\Clock;
 use Lcobucci\JWT\Token;
 use Lcobucci\JWT\UnencryptedToken;
 use Lcobucci\JWT\Validation\ConstraintViolation;
 use Lcobucci\JWT\Validation\ValidAt as ValidAtInterface;
+use Psr\Clock\ClockInterface as Clock;
 
 final class StrictValidAt implements ValidAtInterface
 {


### PR DESCRIPTION
This promotes better interoperability by allowing users to plug any Clock implementation that follows PSR-20 - we still fallback to lcobucci/clock.