### PR TITLE
Remove requirement of core PHP extensions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,6 @@
     ],
     "require": {
         "php": "~8.1.0 || ~8.2.0",
-        "ext-hash": "*",
-        "ext-json": "*",
         "ext-openssl": "*",
         "ext-sodium": "*",
         "psr/clock": "^1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f970740ee2be5fe92340d6c4f46fe2ae",
+    "content-hash": "67fbc5c58fe0ae92e0da017e576ae3ec",
     "packages": [
         {
             "name": "psr/clock",
@@ -4924,8 +4924,6 @@
     "prefer-lowest": false,
     "platform": {
         "php": "~8.1.0 || ~8.2.0",
-        "ext-hash": "*",
-        "ext-json": "*",
         "ext-openssl": "*",
         "ext-sodium": "*"
     },


### PR DESCRIPTION
Since PHP 7.4, `ext-hash` is part of PHP core and cannot be disabled (see https://www.php.net/manual/en/hash.installation.php).
Since PHP 8.0, `ext-json` is part of PHP core and cannot be disabled (see https://www.php.net/manual/en/json.installation.php).

I think they could be removed from `composer.json` require section.