### PR TITLE
Fixed naming of `assertShouldRaiseExceptionWhenSignatureIsValid()`

### DIFF
--- a/tests/Validation/Constraint/SignedWithTest.php
+++ b/tests/Validation/Constraint/SignedWithTest.php
@@ -78,7 +78,7 @@ final class SignedWithTest extends ConstraintTestCase
     }
 
     /** @test */
-    public function assertShouldRaiseExceptionWhenSignatureIsValid(): void
+    public function assertShouldNotRaiseExceptionWhenSignatureIsValid(): void
     {
         $token = $this->buildToken([], ['alg' => 'RS256'], $this->signature);
 


### PR DESCRIPTION
If I understood this test correctly the name should be `assertShould`**`Not`**`RaiseExceptionWhenSignatureIsValid`.