### PR TITLE
Feature: Add DataSet and Signature interfaces

### DIFF
--- a/src/DataSet.php
+++ b/src/DataSet.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace Lcobucci\JWT;
+
+interface DataSet
+{
+    /** @param non-empty-string $name */
+    public function get(string $name, mixed $default = null): mixed;
+
+    /** @param non-empty-string $name */
+    public function has(string $name): bool;
+
+    /** @return array<non-empty-string, mixed> */
+    public function all(): array;
+
+    public function toString(): string;
+}

--- a/src/Signature.php
+++ b/src/Signature.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Lcobucci\JWT;
+
+interface Signature
+{
+    /** @return non-empty-string */
+    public function hash(): string;
+
+    /**
+     * Returns the encoded version of the signature
+     *
+     * @return non-empty-string
+     */
+    public function toString(): string;
+}

--- a/src/Token/DataSet.php
+++ b/src/Token/DataSet.php
@@ -3,9 +3,11 @@ declare(strict_types=1);
 
 namespace Lcobucci\JWT\Token;
 
+use Lcobucci\JWT\DataSet as DataSetInterface;
+
 use function array_key_exists;
 
-final class DataSet
+final class DataSet implements DataSetInterface
 {
     /** @param array<non-empty-string, mixed> $data */
     public function __construct(private readonly array $data, private readonly string $encoded)

--- a/src/Token/Signature.php
+++ b/src/Token/Signature.php
@@ -3,7 +3,9 @@ declare(strict_types=1);
 
 namespace Lcobucci\JWT\Token;
 
-final class Signature
+use Lcobucci\JWT\Signature as SignatureInterface;
+
+final class Signature implements SignatureInterface
 {
     /**
      * @param non-empty-string $hash


### PR DESCRIPTION
With this PR the  `Lcobucci\JWT\Token\Dataset` and the `Lcobucci\JWT\Token\Signature` classes will implement the  `Lcobucci\JWT\Dataset` and the `Lcobucci\JWT\Signature` interface respectively.

In that way we will be able to mock the above classes (since they are final), but also implement the interfaces for a custom implementation.