### PR TITLE
Support for setting claims with an array

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -74,6 +74,15 @@ interface Builder
     public function withClaim(string $name, mixed $value): Builder;
 
     /**
+     * Configures multiple claim items
+     *
+     * @param non-empty-array $claims
+     *
+     * @throws RegisteredClaimGiven When trying to set a registered claim.
+     */
+    public function withClaim(array $claims): Builder;
+
+    /**
      * Returns a signed token to be used
      *
      * @throws CannotEncodeContent When data cannot be converted to JSON.

--- a/src/Token/Builder.php
+++ b/src/Token/Builder.php
@@ -84,6 +84,18 @@ final class Builder implements BuilderInterface
         return $this->setClaim($name, $value);
     }
 
+	public function withClaims(array $claims): BuilderInterface
+	{
+		$new = clone $this;
+		foreach ($claims as $key => $value) {
+			if (in_array($key, RegisteredClaims::ALL, true)) {
+				throw RegisteredClaimGiven::forClaim($key);
+			}
+			$new->claims[$key] = $value;
+		}
+		return $new;
+	}
+
     /** @param non-empty-string $name */
     private function setClaim(string $name, mixed $value): BuilderInterface
     {


### PR DESCRIPTION
In order to make my code cleaner I needed a way to set multiple claims by providing them in an array format. 

This implementation expands the withClaim() by providing this interface. 
Any previously defined claims are protected by the same check that withClaim() is doing.
