### PR TITLE
Remove requirement of core PHP extensions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,6 @@
     ],
     "require": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
-        "ext-hash": "*",
-        "ext-json": "*",
         "ext-openssl": "*",
         "ext-sodium": "*",
         "psr/clock": "^1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eb30412f3b5476124fef57f093daa4c1",
+    "content-hash": "5ba08423e19ae56456ff35b3290fc22d",
     "packages": [
         {
             "name": "psr/clock",
@@ -4934,8 +4934,6 @@
     "prefer-lowest": false,
     "platform": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
-        "ext-hash": "*",
-        "ext-json": "*",
         "ext-openssl": "*",
         "ext-sodium": "*"
     },


### PR DESCRIPTION
This was raised by @cedric-anne but I didn't manage to merge it in time.

More info: https://github.com/lcobucci/jwt/pull/1009