### PR TITLE
Make ext-sodium an optional dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",
-        "ext-sodium": "*",
         "lcobucci/clock": "^2.0 || ^3.0"
     },
     "require-dev": {
@@ -37,6 +36,9 @@
         "phpstan/phpstan-strict-rules": "^1.0",
         "phpunit/php-invoker": "^3.1",
         "phpunit/phpunit": "^9.5"
+    },
+    "suggest": {
+        "ext-sodium": "*"
     },
     "autoload": {
         "psr-4": {

--- a/src/Signer/Blake2b.php
+++ b/src/Signer/Blake2b.php
@@ -5,6 +5,7 @@ namespace Lcobucci\JWT\Signer;
 
 use Lcobucci\JWT\Signer;
 
+use function function_exists;
 use function hash_equals;
 use function sodium_crypto_generichash;
 use function strlen;
@@ -20,6 +21,10 @@ final class Blake2b implements Signer
 
     public function sign(string $payload, Key $key): string
     {
+        if (! function_exists('sodium_crypto_generichash')) {
+            throw ExtSodiumMissing::forBlake2b();
+        }
+
         $actualKeyLength = 8 * strlen($key->contents());
 
         if ($actualKeyLength < self::MINIMUM_KEY_LENGTH_IN_BITS) {

--- a/src/Signer/Eddsa.php
+++ b/src/Signer/Eddsa.php
@@ -6,6 +6,7 @@ namespace Lcobucci\JWT\Signer;
 use Lcobucci\JWT\Signer;
 use SodiumException;
 
+use function function_exists;
 use function sodium_crypto_sign_detached;
 use function sodium_crypto_sign_verify_detached;
 
@@ -18,6 +19,10 @@ final class Eddsa implements Signer
 
     public function sign(string $payload, Key $key): string
     {
+        if (! function_exists('sodium_crypto_sign_detached')) {
+            throw ExtSodiumMissing::forEddsa();
+        }
+
         try {
             return sodium_crypto_sign_detached($payload, $key->contents());
         } catch (SodiumException $sodiumException) {
@@ -27,6 +32,10 @@ final class Eddsa implements Signer
 
     public function verify(string $expected, string $payload, Key $key): bool
     {
+        if (! function_exists('sodium_crypto_sign_verify_detached')) {
+            throw ExtSodiumMissing::forEddsa();
+        }
+
         try {
             return sodium_crypto_sign_verify_detached($expected, $payload, $key->contents());
         } catch (SodiumException $sodiumException) {

--- a/src/Signer/ExtSodiumMissing.php
+++ b/src/Signer/ExtSodiumMissing.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace Lcobucci\JWT\Signer;
+
+use Lcobucci\JWT\Exception;
+use LogicException;
+
+final class ExtSodiumMissing extends LogicException implements Exception
+{
+    public static function forEddsa(): self
+    {
+        return new self('EdDSA signer requires PHP extension ext-sodium to be installed');
+    }
+
+    public static function forBlake2b(): self
+    {
+        return new self('BLAKE2B signer requires PHP extension ext-sodium to be installed');
+    }
+}


### PR DESCRIPTION
It looks to me like `ext-sodium` is only needed for the two signers `BLAKE2B` and `EdDSA`. 

It would be great if we could move `"ext-sodium": "*"` from `"require"` to `"suggest"` in order to make this library installable even if the Sodium extension is not enabled. This should be fine for all usages of this library that do not use `BLAKE2B` or `EdDSA` which seems to be the case quite often.

Is the 4.3.x branch the correct one for this pull request?