### PR TITLE
Add constraint to verify the existence of a custom claim

### DIFF
--- a/docs/validating-tokens.md
+++ b/docs/validating-tokens.md
@@ -90,6 +90,6 @@ This library provides the following constraints:
 * `Lcobucci\JWT\Validation\Constraint\StrictValidAt`: verifies presence and validity of the claims `iat`, `nbf`, and `exp` (supports leeway configuration)
 * `Lcobucci\JWT\Validation\Constraint\LooseValidAt`: verifies the claims `iat`, `nbf`, and `exp`, when present (supports leeway configuration)
 * `Lcobucci\JWT\Validation\Constraint\HasClaimWithValue`: verifies that a **custom claim** has the expected value (not recommended when comparing cryptographic hashes)
-* `Lcobucci\JWT\Validation\Constraint\HasClaim`: verifies that a claim is present
+* `Lcobucci\JWT\Validation\Constraint\HasClaim`: verifies that a **custom claim** is present
 
 You may also create your [own validation constraints](extending-the-library.md#validation-constraints).

--- a/docs/validating-tokens.md
+++ b/docs/validating-tokens.md
@@ -90,5 +90,6 @@ This library provides the following constraints:
 * `Lcobucci\JWT\Validation\Constraint\StrictValidAt`: verifies presence and validity of the claims `iat`, `nbf`, and `exp` (supports leeway configuration)
 * `Lcobucci\JWT\Validation\Constraint\LooseValidAt`: verifies the claims `iat`, `nbf`, and `exp`, when present (supports leeway configuration)
 * `Lcobucci\JWT\Validation\Constraint\HasClaimWithValue`: verifies that a **custom claim** has the expected value (not recommended when comparing cryptographic hashes)
+* `Lcobucci\JWT\Validation\Constraint\HasClaim`: verifies that a claim is present
 
 You may also create your [own validation constraints](extending-the-library.md#validation-constraints).

--- a/src/Validation/Constraint/HasClaim.php
+++ b/src/Validation/Constraint/HasClaim.php
@@ -8,11 +8,16 @@ use Lcobucci\JWT\UnencryptedToken;
 use Lcobucci\JWT\Validation\Constraint;
 use Lcobucci\JWT\Validation\ConstraintViolation;
 
+use function in_array;
+
 final class HasClaim implements Constraint
 {
     /** @param non-empty-string $claim */
     public function __construct(private readonly string $claim)
     {
+        if (in_array($claim, Token\RegisteredClaims::ALL, true)) {
+            throw CannotValidateARegisteredClaim::create($claim);
+        }
     }
 
     public function assert(Token $token): void

--- a/src/Validation/Constraint/HasClaim.php
+++ b/src/Validation/Constraint/HasClaim.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Lcobucci\JWT\Validation\Constraint;
+
+use Lcobucci\JWT\Token;
+use Lcobucci\JWT\UnencryptedToken;
+use Lcobucci\JWT\Validation\Constraint;
+use Lcobucci\JWT\Validation\ConstraintViolation;
+
+final class HasClaim implements Constraint
+{
+    /** @param non-empty-string $claim */
+    public function __construct(private readonly string $claim)
+    {
+    }
+
+    public function assert(Token $token): void
+    {
+        if (! $token instanceof UnencryptedToken) {
+            throw ConstraintViolation::error('You should pass a plain token', $this);
+        }
+
+        $claims = $token->claims();
+
+        if (! $claims->has($this->claim)) {
+            throw ConstraintViolation::error('The token does not have the claim "' . $this->claim . '"', $this);
+        }
+    }
+}

--- a/tests/Validation/Constraint/HasClaimTest.php
+++ b/tests/Validation/Constraint/HasClaimTest.php
@@ -47,21 +47,24 @@ final class HasClaimTest extends ConstraintTestCase
     /** @test */
     public function assertShouldRaiseExceptionWhenClaimIsNotSet(): void
     {
+        $constraint = new HasClaim('claimId');
+
         $this->expectException(ConstraintViolation::class);
         $this->expectExceptionMessage('The token does not have the claim "claimId"');
 
-        $constraint = new HasClaim('claimId');
         $constraint->assert($this->buildToken());
     }
 
     /** @test */
     public function assertShouldRaiseExceptionWhenTokenIsNotAPlainToken(): void
     {
+        $token      = $this->createMock(Token::class);
+        $constraint = new HasClaim('claimId');
+
         $this->expectException(ConstraintViolation::class);
         $this->expectExceptionMessage('You should pass a plain token');
 
-        $constraint = new HasClaim('claimId');
-        $constraint->assert($this->createMock(Token::class));
+        $constraint->assert($token);
     }
 
     /** @test */

--- a/tests/Validation/Constraint/HasClaimTest.php
+++ b/tests/Validation/Constraint/HasClaimTest.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+namespace Lcobucci\JWT\Tests\Validation\Constraint;
+
+use Lcobucci\JWT\Token;
+use Lcobucci\JWT\Validation\Constraint\HasClaim;
+use Lcobucci\JWT\Validation\ConstraintViolation;
+
+/**
+ * @covers \Lcobucci\JWT\Validation\ConstraintViolation
+ * @covers \Lcobucci\JWT\Validation\Constraint\HasClaim
+ *
+ * @uses \Lcobucci\JWT\Token\DataSet
+ * @uses \Lcobucci\JWT\Token\Plain
+ * @uses \Lcobucci\JWT\Token\Signature
+ */
+final class HasClaimTest extends ConstraintTestCase
+{
+    /** @test */
+    public function assertShouldRaiseExceptionWhenClaimIsNotSet(): void
+    {
+        $this->expectException(ConstraintViolation::class);
+        $this->expectExceptionMessage('The token does not have the claim "claimId"');
+
+        $constraint = new HasClaim('claimId');
+        $constraint->assert($this->buildToken());
+    }
+
+    /** @test */
+    public function assertShouldRaiseExceptionWhenTokenIsNotAPlainToken(): void
+    {
+        $this->expectException(ConstraintViolation::class);
+        $this->expectExceptionMessage('You should pass a plain token');
+
+        $constraint = new HasClaim('claimId');
+        $constraint->assert($this->createMock(Token::class));
+    }
+
+    /** @test */
+    public function assertShouldNotRaiseExceptionWhenClaimMatches(): void
+    {
+        $token      = $this->buildToken(['claimId' => 'claimValue']);
+        $constraint = new HasClaim('claimId');
+
+        $constraint->assert($token);
+        $this->addToAssertionCount(1);
+    }
+}

--- a/tests/Validation/Constraint/HasClaimTest.php
+++ b/tests/Validation/Constraint/HasClaimTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Lcobucci\JWT\Tests\Validation\Constraint;
 
 use Lcobucci\JWT\Token;
+use Lcobucci\JWT\Validation\Constraint\CannotValidateARegisteredClaim;
 use Lcobucci\JWT\Validation\Constraint\HasClaim;
 use Lcobucci\JWT\Validation\ConstraintViolation;
 
@@ -17,6 +18,32 @@ use Lcobucci\JWT\Validation\ConstraintViolation;
  */
 final class HasClaimTest extends ConstraintTestCase
 {
+    /**
+     * @test
+     * @dataProvider registeredClaims
+     *
+     * @covers \Lcobucci\JWT\Validation\Constraint\CannotValidateARegisteredClaim
+     *
+     * @param non-empty-string $claim
+     */
+    public function registeredClaimsCannotBeValidatedUsingThisConstraint(string $claim): void
+    {
+        $this->expectException(CannotValidateARegisteredClaim::class);
+        $this->expectExceptionMessage(
+            'The claim "' . $claim . '" is a registered claim, another constraint must be used to validate its value',
+        );
+
+        new HasClaim($claim);
+    }
+
+    /** @return iterable<non-empty-string, array{non-empty-string}> */
+    public static function registeredClaims(): iterable
+    {
+        foreach (Token\RegisteredClaims::ALL as $claim) {
+            yield $claim => [$claim];
+        }
+    }
+
     /** @test */
     public function assertShouldRaiseExceptionWhenClaimIsNotSet(): void
     {


### PR DESCRIPTION
Hello!

I want to add a HasClaim constraint that validates a presence of claim in token.

It useful for custom claims with non stable values (device_id etc.)