### PR TITLE
Add `#[SensitiveParameter]` attribute to sensitive parameters

### DIFF
--- a/src/Signer/Key/InMemory.php
+++ b/src/Signer/Key/InMemory.php
@@ -6,6 +6,7 @@ namespace Lcobucci\JWT\Signer\Key;
 use Lcobucci\JWT\Signer\InvalidKeyProvided;
 use Lcobucci\JWT\Signer\Key;
 use Lcobucci\JWT\SodiumBase64Polyfill;
+use SensitiveParameter;
 use SplFileObject;
 use Throwable;
 
@@ -15,21 +16,33 @@ use function is_string;
 final class InMemory implements Key
 {
     /** @param non-empty-string $contents */
-    private function __construct(public readonly string $contents, public readonly string $passphrase)
-    {
+    private function __construct(
+        #[SensitiveParameter]
+        public readonly string $contents,
+        #[SensitiveParameter]
+        public readonly string $passphrase,
+    ) {
     }
 
     /** @param non-empty-string $contents */
-    public static function plainText(string $contents, string $passphrase = ''): self
-    {
+    public static function plainText(
+        #[SensitiveParameter]
+        string $contents,
+        #[SensitiveParameter]
+        string $passphrase = '',
+    ): self {
         self::guardAgainstEmptyKey($contents);
 
         return new self($contents, $passphrase);
     }
 
     /** @param non-empty-string $contents */
-    public static function base64Encoded(string $contents, string $passphrase = ''): self
-    {
+    public static function base64Encoded(
+        #[SensitiveParameter]
+        string $contents,
+        #[SensitiveParameter]
+        string $passphrase = '',
+    ): self {
         $decoded = SodiumBase64Polyfill::base642bin(
             $contents,
             SodiumBase64Polyfill::SODIUM_BASE64_VARIANT_ORIGINAL,
@@ -45,8 +58,11 @@ final class InMemory implements Key
      *
      * @throws FileCouldNotBeRead
      */
-    public static function file(string $path, string $passphrase = ''): self
-    {
+    public static function file(
+        string $path,
+        #[SensitiveParameter]
+        string $passphrase = '',
+    ): self {
         try {
             $file = new SplFileObject($path);
         } catch (Throwable $exception) {

--- a/src/Signer/OpenSSL.php
+++ b/src/Signer/OpenSSL.php
@@ -5,6 +5,7 @@ namespace Lcobucci\JWT\Signer;
 
 use Lcobucci\JWT\Signer;
 use OpenSSLAsymmetricKey;
+use SensitiveParameter;
 
 use function array_key_exists;
 use function assert;
@@ -40,7 +41,9 @@ abstract class OpenSSL implements Signer
      * @throws InvalidKeyProvided
      */
     final protected function createSignature(
+        #[SensitiveParameter]
         string $pem,
+        #[SensitiveParameter]
         string $passphrase,
         string $payload,
     ): string {
@@ -56,8 +59,12 @@ abstract class OpenSSL implements Signer
     }
 
     /** @throws CannotSignPayload */
-    private function getPrivateKey(string $pem, string $passphrase): OpenSSLAsymmetricKey
-    {
+    private function getPrivateKey(
+        #[SensitiveParameter]
+        string $pem,
+        #[SensitiveParameter]
+        string $passphrase,
+    ): OpenSSLAsymmetricKey {
         return $this->validateKey(openssl_pkey_get_private($pem, $passphrase));
     }
 


### PR DESCRIPTION
Fixes #1081, adds `#[SensitiveParameter]` to all potentially sensitive parameters, including key material, certificates and passphrases.

I wondered if this would be a BC break, but it seems that that is not the case. Child classes/interface implementations can apparently omit the attribute without any problems.