### PR TITLE
fix: prevent undefined array key errors in KEY_TYPE_MAP access

### DIFF
--- a/src/Signer/Ecdsa.php
+++ b/src/Signer/Ecdsa.php
@@ -38,7 +38,7 @@ abstract readonly class Ecdsa extends OpenSSL
         if ($type !== OPENSSL_KEYTYPE_EC) {
             throw InvalidKeyProvided::incompatibleKeyType(
                 self::KEY_TYPE_MAP[OPENSSL_KEYTYPE_EC],
-                self::KEY_TYPE_MAP[$type],
+                self::KEY_TYPE_MAP[$type] ?? 'unknown',
             );
         }
 

--- a/src/Signer/Rsa.php
+++ b/src/Signer/Rsa.php
@@ -24,7 +24,7 @@ abstract readonly class Rsa extends OpenSSL
         if ($type !== OPENSSL_KEYTYPE_RSA) {
             throw InvalidKeyProvided::incompatibleKeyType(
                 self::KEY_TYPE_MAP[OPENSSL_KEYTYPE_RSA],
-                self::KEY_TYPE_MAP[$type],
+                self::KEY_TYPE_MAP[$type] ?? 'unknown',
             );
         }
 


### PR DESCRIPTION
currently, `Static Analysis` action is failing
https://github.com/lcobucci/jwt/actions/workflows/static-analysis.yml

```
 ------ ----------------------------------------------------------------------- 
  Line   src/Signer/Ecdsa.php                                                   
 ------ ----------------------------------------------------------------------- 
  41     Offset int<min, 2>|int<4, max> might not exist on array{'RSA', 'DSA',  
          'DH', 'EC'}.                                                          
         🪪  offsetAccess.notFound                                              
 ------ ----------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------- 
  Line   src/Signer/Rsa.php                                                     
 ------ ----------------------------------------------------------------------- 
  27     Offset int<min, -1>|int<1, max> might not exist on array{'RSA', 'DSA'  
         , 'DH', 'EC'}.                                                         
         🪪  offsetAccess.notFound                                              
 ------ ----------------------------------------------------------------------- 

Error:  [ERROR] Found 2 errors                             
```