### PR TITLE
Allow 1024 bit keys to be the minimum key length

### DIFF
--- a/src/Signer/Rsa.php
+++ b/src/Signer/Rsa.php
@@ -7,7 +7,7 @@ use const OPENSSL_KEYTYPE_RSA;
 
 abstract class Rsa extends OpenSSL
 {
-    private const MINIMUM_KEY_LENGTH = 2048;
+    private const MINIMUM_KEY_LENGTH = 1024;
 
     final public function sign(string $payload, Key $key): string
     {


### PR DESCRIPTION
This change only servers as a way to allow us to upgrade to a higher version of Symfony while we migrate our keys to 2048 bit keys and let our users aquire access/refresh tokens based on the 2048 after their current tokens expire. After a while we will switch back to the official lcobucci/jwt package.